### PR TITLE
Add mobile-responsive dual-view layout to DailyReview

### DIFF
--- a/frontend/src/components/DailyReview/DailyReview.test.jsx
+++ b/frontend/src/components/DailyReview/DailyReview.test.jsx
@@ -211,7 +211,9 @@ describe('DailyReview', () => {
     it('should display empty state when no entries', () => {
       renderWithRouter(<DailyReview />);
 
-      expect(screen.getByText(/No entries for this date/i)).toBeInTheDocument();
+      // Now there are two empty states (one in table, one in mobile view)
+      const emptyMessages = screen.getAllByText(/No entries for this date/i);
+      expect(emptyMessages.length).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -295,6 +297,125 @@ describe('DailyReview Export Functions', () => {
       expect(summaryContent).toContain('Flagged: 2');
       expect(summaryContent).toContain('No Checkout: 1');
       expect(summaryContent).toContain('Modified: 3');
+    });
+  });
+});
+
+describe('DailyReview Mobile Responsive Layout', () => {
+  describe('dual-view rendering', () => {
+    it('should render both desktop table and mobile card containers', () => {
+      renderWithRouter(<DailyReview />);
+
+      // Desktop table view should exist (using table role)
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+
+      // Mobile card view should exist (using list role)
+      const mobileList = screen.getByRole('list', { name: 'Daily time entries' });
+      expect(mobileList).toBeInTheDocument();
+    });
+
+    it('should render table with proper role and aria-label', () => {
+      renderWithRouter(<DailyReview />);
+
+      const table = screen.getByRole('table');
+      expect(table).toHaveAttribute('aria-label', 'Daily time entries');
+    });
+
+    it('should render mobile list with proper role and aria-label', () => {
+      renderWithRouter(<DailyReview />);
+
+      const mobileList = screen.getByRole('list', { name: 'Daily time entries' });
+      expect(mobileList).toBeInTheDocument();
+    });
+
+    it('should render table headers with scope attributes', () => {
+      renderWithRouter(<DailyReview />);
+
+      const columnHeaders = screen.getAllByRole('columnheader');
+      columnHeaders.forEach(header => {
+        expect(header).toHaveAttribute('scope', 'col');
+      });
+    });
+  });
+
+  describe('empty state', () => {
+    it('should display empty message in both views when no entries', () => {
+      renderWithRouter(<DailyReview />);
+
+      // Check for empty state messages (one in table, one in mobile view)
+      const emptyMessages = screen.getAllByText(/No entries for this date/i);
+      expect(emptyMessages.length).toBe(2); // One in table, one in mobile view
+    });
+
+    it('should display filter empty message in both views', async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<DailyReview />);
+
+      // Type in search box to trigger filter
+      const searchInput = screen.getByPlaceholderText('Search students...');
+      await user.type(searchInput, 'NonexistentStudent');
+
+      // Check for filter empty state messages
+      const emptyMessages = screen.getAllByText(/No entries match your filters/i);
+      expect(emptyMessages.length).toBe(2); // One in table, one in mobile view
+    });
+  });
+
+  describe('CSS class verification', () => {
+    it('should have correct responsive classes on table container', () => {
+      renderWithRouter(<DailyReview />);
+
+      // Verify the table exists and has the expected structure
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+
+      // Verify the table container has responsive hiding class
+      const tableContainer = table.closest('div');
+      expect(tableContainer.className).toContain('hidden');
+      expect(tableContainer.className).toContain('md:block');
+    });
+
+    it('should have correct responsive classes on mobile container', () => {
+      renderWithRouter(<DailyReview />);
+
+      // Verify mobile list exists
+      const mobileList = screen.getByRole('list', { name: 'Daily time entries' });
+      expect(mobileList).toBeInTheDocument();
+
+      // Verify the mobile container has responsive classes
+      expect(mobileList.className).toContain('block');
+      expect(mobileList.className).toContain('md:hidden');
+    });
+  });
+});
+
+describe('DailyReview Accessibility', () => {
+  describe('table accessibility', () => {
+    it('should have table with aria-label', () => {
+      renderWithRouter(<DailyReview />);
+
+      const table = screen.getByRole('table');
+      expect(table).toHaveAttribute('aria-label');
+    });
+
+    it('should have all column headers with scope="col"', () => {
+      renderWithRouter(<DailyReview />);
+
+      const headers = screen.getAllByRole('columnheader');
+      expect(headers).toHaveLength(8); // Date, Name, Activity, Check-In, Check-Out, Hours, Status, Actions
+      headers.forEach(header => {
+        expect(header).toHaveAttribute('scope', 'col');
+      });
+    });
+  });
+
+  describe('mobile view accessibility', () => {
+    it('should have mobile list container with role="list"', () => {
+      renderWithRouter(<DailyReview />);
+
+      const mobileList = screen.getByRole('list', { name: 'Daily time entries' });
+      expect(mobileList).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/DailyReview/TimeEntryCard.jsx
+++ b/frontend/src/components/DailyReview/TimeEntryCard.jsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import Button from '../common/Button';
+
+/**
+ * TimeEntryCard Component
+ * Mobile-friendly card view for time entries (used on screens < md breakpoint)
+ *
+ * @param {Object} entry - The time entry object with student, activity, and time data
+ * @param {Function} formatTime - Function to format time values
+ * @param {Function} formatHours - Function to format hours values
+ * @param {Function} getStatusDisplay - Function to get status display text
+ * @param {Function} getStatusClass - Function to get status CSS class
+ * @param {Function} onEdit - Callback when edit button is clicked
+ * @param {Function} onForceCheckout - Callback when force checkout button is clicked
+ */
+export default function TimeEntryCard({
+  entry,
+  formatTime,
+  formatHours,
+  getStatusDisplay,
+  getStatusClass,
+  onEdit,
+  onForceCheckout
+}) {
+  const studentName = `${entry.student.lastName}, ${entry.student.firstName}`;
+  const activityName = entry.activity?.name || '--';
+  const checkInTimeDisplay = entry.checkInTime ? formatTime(entry.checkInTime) : '--';
+  const checkOutTimeDisplay = entry.checkOutTime
+    ? formatTime(entry.checkOutTime)
+    : 'Not checked out';
+  const hoursDisplay = entry.hoursWorked !== null && entry.hoursWorked !== undefined
+    ? formatHours(entry.hoursWorked)
+    : '--';
+  const dateDisplay = entry.checkInTime
+    ? new Date(entry.checkInTime).toLocaleDateString()
+    : entry.date;
+
+  return (
+    <article
+      className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
+      aria-label={`Time entry for ${entry.student.firstName} ${entry.student.lastName}`}
+    >
+      {/* Header: Name and Status */}
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex-1 min-w-0">
+          <h3
+            className="font-medium text-gray-900 truncate"
+            title={studentName}
+          >
+            {studentName}
+          </h3>
+          <span
+            className="inline-block uppercase font-bold text-[10px] text-blue-600 mt-1"
+            title={activityName}
+          >
+            {activityName}
+          </span>
+        </div>
+        <span
+          className={`text-sm font-medium whitespace-nowrap ml-2 ${getStatusClass(entry)}`}
+          aria-label={`Status: ${getStatusDisplay(entry).replace(/[^\w\s]/g, '')}`}
+        >
+          {getStatusDisplay(entry)}
+        </span>
+      </div>
+
+      {/* Date Row */}
+      <div className="text-xs text-gray-500 mb-3">
+        {dateDisplay}
+      </div>
+
+      {/* Time Details Grid */}
+      <div className="grid grid-cols-3 gap-2 text-sm mb-3">
+        <div>
+          <span className="block text-xs text-gray-500 uppercase" aria-hidden="true">Check-In</span>
+          <span className="text-gray-900" aria-label={`Check-in time: ${checkInTimeDisplay}`}>
+            {checkInTimeDisplay}
+          </span>
+        </div>
+        <div>
+          <span className="block text-xs text-gray-500 uppercase" aria-hidden="true">Check-Out</span>
+          <span
+            className={entry.checkOutTime ? 'text-gray-900' : 'text-red-600 font-medium'}
+            aria-label={`Check-out time: ${checkOutTimeDisplay}`}
+          >
+            {checkOutTimeDisplay}
+          </span>
+        </div>
+        <div>
+          <span className="block text-xs text-gray-500 uppercase" aria-hidden="true">Hours</span>
+          <span className="text-gray-900" aria-label={`Hours worked: ${hoursDisplay}`}>
+            {hoursDisplay}
+          </span>
+        </div>
+      </div>
+
+      {/* Override/Modification Reason if present */}
+      {(entry.forcedCheckoutReason || entry.modificationReason) && (
+        <div
+          className="text-xs text-blue-600 italic bg-blue-50 p-2 rounded mb-3 truncate"
+          title={entry.forcedCheckoutReason || entry.modificationReason}
+        >
+          Override: {entry.forcedCheckoutReason || entry.modificationReason}
+        </div>
+      )}
+
+      {/* Flags if present */}
+      {entry.flags && entry.flags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          {entry.flags.map((flag, index) => (
+            <span
+              key={index}
+              className="inline-block text-xs bg-amber-100 text-amber-800 px-2 py-0.5 rounded-full"
+            >
+              {formatFlag(flag)}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex gap-2 pt-2 border-t border-gray-100">
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => onEdit(entry)}
+          aria-label={`Edit time entry for ${entry.student.firstName} ${entry.student.lastName}`}
+        >
+          Edit
+        </Button>
+        {!entry.checkOutTime && (
+          <Button
+            size="sm"
+            variant="danger"
+            onClick={() => onForceCheckout(entry)}
+            aria-label={`Force checkout for ${entry.student.firstName} ${entry.student.lastName}`}
+          >
+            Force Out
+          </Button>
+        )}
+      </div>
+    </article>
+  );
+}
+
+/**
+ * Format flag values to human-readable labels
+ */
+function formatFlag(flag) {
+  const flagLabels = {
+    early_arrival: 'Early arrival',
+    late_stay: 'Late stay',
+    forced_checkout: 'Forced checkout'
+  };
+  return flagLabels[flag] || flag;
+}

--- a/frontend/src/components/DailyReview/TimeEntryCard.test.jsx
+++ b/frontend/src/components/DailyReview/TimeEntryCard.test.jsx
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TimeEntryCard from './TimeEntryCard';
+
+// Mock Button component
+vi.mock('../common/Button', () => ({
+  default: ({ children, onClick, variant, size, 'aria-label': ariaLabel }) => (
+    <button
+      onClick={onClick}
+      data-variant={variant}
+      data-size={size}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  )
+}));
+
+describe('TimeEntryCard', () => {
+  const mockEntry = {
+    id: 'entry1',
+    date: '2026-01-31',
+    student: {
+      firstName: 'John',
+      lastName: 'Doe'
+    },
+    activity: {
+      name: 'Morning Session'
+    },
+    checkInTime: new Date('2026-01-31T08:00:00'),
+    checkOutTime: new Date('2026-01-31T12:00:00'),
+    hoursWorked: 4,
+    flags: [],
+    forcedCheckoutReason: null,
+    modificationReason: null
+  };
+
+  const mockFormatTime = (date) => {
+    if (!date) return '--';
+    return new Date(date).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  };
+
+  const mockFormatHours = (hours) => `${hours.toFixed(1)} hours`;
+
+  const mockGetStatusDisplay = (entry) => {
+    if (!entry.checkOutTime) return '🔴 No Checkout';
+    if (entry.forcedCheckoutReason) return '⚡ Forced';
+    if (entry.modificationReason) return '✏️ Modified';
+    if (entry.flags && entry.flags.length > 0) return '⚠️ Flagged';
+    return '✓ Complete';
+  };
+
+  const mockGetStatusClass = (entry) => {
+    if (!entry.checkOutTime) return 'text-red-600';
+    if (entry.forcedCheckoutReason || entry.modificationReason) return 'text-blue-600';
+    if (entry.flags && entry.flags.length > 0) return 'text-amber-600';
+    return 'text-green-600';
+  };
+
+  const defaultProps = {
+    entry: mockEntry,
+    formatTime: mockFormatTime,
+    formatHours: mockFormatHours,
+    getStatusDisplay: mockGetStatusDisplay,
+    getStatusClass: mockGetStatusClass,
+    onEdit: vi.fn(),
+    onForceCheckout: vi.fn()
+  };
+
+  describe('rendering', () => {
+    it('should render student name', () => {
+      render(<TimeEntryCard {...defaultProps} />);
+
+      expect(screen.getByText('Doe, John')).toBeInTheDocument();
+    });
+
+    it('should render activity name', () => {
+      render(<TimeEntryCard {...defaultProps} />);
+
+      expect(screen.getByText('Morning Session')).toBeInTheDocument();
+    });
+
+    it('should render check-in time', () => {
+      render(<TimeEntryCard {...defaultProps} />);
+
+      expect(screen.getByText('Check-In')).toBeInTheDocument();
+    });
+
+    it('should render check-out time', () => {
+      render(<TimeEntryCard {...defaultProps} />);
+
+      expect(screen.getByText('Check-Out')).toBeInTheDocument();
+    });
+
+    it('should render hours worked', () => {
+      render(<TimeEntryCard {...defaultProps} />);
+
+      expect(screen.getByText('4.0 hours')).toBeInTheDocument();
+    });
+
+    it('should render status', () => {
+      render(<TimeEntryCard {...defaultProps} />);
+
+      expect(screen.getByText('✓ Complete')).toBeInTheDocument();
+    });
+
+    it('should render Edit button', () => {
+      render(<TimeEntryCard {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+    });
+
+    it('should not render Force Out button when checked out', () => {
+      render(<TimeEntryCard {...defaultProps} />);
+
+      expect(screen.queryByRole('button', { name: /force checkout/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('entry without checkout', () => {
+    const entryNoCheckout = {
+      ...mockEntry,
+      checkOutTime: null,
+      hoursWorked: null
+    };
+
+    it('should display "Not checked out" when no checkout time', () => {
+      render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} />);
+
+      expect(screen.getByText('Not checked out')).toBeInTheDocument();
+    });
+
+    it('should render Force Out button when not checked out', () => {
+      render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} />);
+
+      expect(screen.getByRole('button', { name: /force checkout/i })).toBeInTheDocument();
+    });
+
+    it('should display No Checkout status', () => {
+      render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} />);
+
+      expect(screen.getByText('🔴 No Checkout')).toBeInTheDocument();
+    });
+
+    it('should display -- for hours when null', () => {
+      render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} />);
+
+      expect(screen.getByText('--')).toBeInTheDocument();
+    });
+  });
+
+  describe('entry with forced checkout', () => {
+    const entryForced = {
+      ...mockEntry,
+      forcedCheckoutReason: 'End of day'
+    };
+
+    it('should display override reason', () => {
+      render(<TimeEntryCard {...defaultProps} entry={entryForced} />);
+
+      expect(screen.getByText(/Override: End of day/)).toBeInTheDocument();
+    });
+
+    it('should display Forced status', () => {
+      render(<TimeEntryCard {...defaultProps} entry={entryForced} />);
+
+      expect(screen.getByText('⚡ Forced')).toBeInTheDocument();
+    });
+  });
+
+  describe('entry with modification', () => {
+    const entryModified = {
+      ...mockEntry,
+      modificationReason: 'Time adjusted by supervisor'
+    };
+
+    it('should display modification reason', () => {
+      render(<TimeEntryCard {...defaultProps} entry={entryModified} />);
+
+      expect(screen.getByText(/Override: Time adjusted by supervisor/)).toBeInTheDocument();
+    });
+
+    it('should display Modified status', () => {
+      render(<TimeEntryCard {...defaultProps} entry={entryModified} />);
+
+      expect(screen.getByText('✏️ Modified')).toBeInTheDocument();
+    });
+  });
+
+  describe('entry with flags', () => {
+    const entryFlagged = {
+      ...mockEntry,
+      flags: ['early_arrival', 'late_stay']
+    };
+
+    it('should display flag badges', () => {
+      render(<TimeEntryCard {...defaultProps} entry={entryFlagged} />);
+
+      expect(screen.getByText('Early arrival')).toBeInTheDocument();
+      expect(screen.getByText('Late stay')).toBeInTheDocument();
+    });
+
+    it('should display Flagged status', () => {
+      render(<TimeEntryCard {...defaultProps} entry={entryFlagged} />);
+
+      expect(screen.getByText('⚠️ Flagged')).toBeInTheDocument();
+    });
+  });
+
+  describe('interactions', () => {
+    it('should call onEdit when Edit button is clicked', async () => {
+      const user = userEvent.setup();
+      const onEdit = vi.fn();
+
+      render(<TimeEntryCard {...defaultProps} onEdit={onEdit} />);
+
+      await user.click(screen.getByRole('button', { name: /edit/i }));
+
+      expect(onEdit).toHaveBeenCalledWith(mockEntry);
+    });
+
+    it('should call onForceCheckout when Force Out button is clicked', async () => {
+      const user = userEvent.setup();
+      const onForceCheckout = vi.fn();
+      const entryNoCheckout = { ...mockEntry, checkOutTime: null };
+
+      render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} onForceCheckout={onForceCheckout} />);
+
+      await user.click(screen.getByRole('button', { name: /force checkout/i }));
+
+      expect(onForceCheckout).toHaveBeenCalledWith(entryNoCheckout);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have aria-label on the card article', () => {
+      render(<TimeEntryCard {...defaultProps} />);
+
+      const article = screen.getByRole('article');
+      expect(article).toHaveAttribute('aria-label', 'Time entry for John Doe');
+    });
+
+    it('should have title attributes for truncation', () => {
+      render(<TimeEntryCard {...defaultProps} />);
+
+      const nameElement = screen.getByText('Doe, John');
+      expect(nameElement).toHaveAttribute('title', 'Doe, John');
+
+      const activityElement = screen.getByText('Morning Session');
+      expect(activityElement).toHaveAttribute('title', 'Morning Session');
+    });
+
+    it('should have aria-label on Edit button', () => {
+      render(<TimeEntryCard {...defaultProps} />);
+
+      const editButton = screen.getByRole('button', { name: /edit/i });
+      expect(editButton).toHaveAttribute('aria-label', 'Edit time entry for John Doe');
+    });
+
+    it('should have aria-label on Force Out button when visible', () => {
+      const entryNoCheckout = { ...mockEntry, checkOutTime: null };
+      render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} />);
+
+      const forceOutButton = screen.getByRole('button', { name: /force checkout/i });
+      expect(forceOutButton).toHaveAttribute('aria-label', 'Force checkout for John Doe');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle missing activity gracefully', () => {
+      const entryNoActivity = {
+        ...mockEntry,
+        activity: null
+      };
+
+      render(<TimeEntryCard {...defaultProps} entry={entryNoActivity} />);
+
+      // Should render -- for missing activity
+      expect(screen.getByTitle('--')).toBeInTheDocument();
+    });
+
+    it('should handle unknown student gracefully', () => {
+      const entryUnknown = {
+        ...mockEntry,
+        student: { firstName: 'Unknown', lastName: 'Student' }
+      };
+
+      render(<TimeEntryCard {...defaultProps} entry={entryUnknown} />);
+
+      expect(screen.getByText('Student, Unknown')).toBeInTheDocument();
+    });
+
+    it('should handle zero hours worked', () => {
+      const entryZeroHours = {
+        ...mockEntry,
+        hoursWorked: 0
+      };
+
+      render(<TimeEntryCard {...defaultProps} entry={entryZeroHours} />);
+
+      expect(screen.getByText('0.0 hours')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/DailyReview/index.jsx
+++ b/frontend/src/components/DailyReview/index.jsx
@@ -8,6 +8,7 @@ import { printInNewWindow, createPrintDocument } from '../../utils/printUtils';
 import Header from '../common/Header';
 import Button from '../common/Button';
 import Modal from '../common/Modal';
+import TimeEntryCard from './TimeEntryCard';
 
 /**
  * Daily Review Component
@@ -667,19 +668,19 @@ export default function DailyReview() {
           </div>
         </div>
 
-        {/* Student List */}
-        <div className="bg-white rounded-lg shadow-md overflow-hidden">
-          <table className="w-full">
+        {/* Desktop Table View (md and up) */}
+        <div className="hidden md:block bg-white rounded-lg shadow-md overflow-hidden">
+          <table className="w-full" role="table" aria-label="Daily time entries">
             <thead className="bg-gray-50 border-b">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Activity</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Check-In</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Check-Out</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Hours</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Activity</th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Check-In</th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Check-Out</th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Hours</th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
               </tr>
             </thead>
             <tbody className="divide-y">
@@ -704,12 +705,18 @@ export default function DailyReview() {
                       {entry.checkInTime ? new Date(entry.checkInTime).toLocaleDateString() : entry.date}
                     </td>
                     <td className="px-4 py-3">
-                      <div className="font-medium text-gray-900">
+                      <div
+                        className="font-medium text-gray-900 truncate max-w-[200px]"
+                        title={`${entry.student.lastName}, ${entry.student.firstName}`}
+                      >
                         {entry.student.lastName}, {entry.student.firstName}
                       </div>
                     </td>
                     <td className="px-4 py-3">
-                      <span className="uppercase font-bold text-[10px] text-blue-600">
+                      <span
+                        className="uppercase font-bold text-[10px] text-blue-600 truncate block max-w-[120px]"
+                        title={entry.activity?.name || '--'}
+                      >
                         {entry.activity?.name || '--'}
                       </span>
                     </td>
@@ -739,6 +746,7 @@ export default function DailyReview() {
                           size="sm"
                           variant="secondary"
                           onClick={() => openEditModal(entry)}
+                          aria-label={`Edit time entry for ${entry.student.firstName} ${entry.student.lastName}`}
                         >
                           Edit
                         </Button>
@@ -747,6 +755,7 @@ export default function DailyReview() {
                             size="sm"
                             variant="danger"
                             onClick={() => openForceCheckoutModal(entry)}
+                            aria-label={`Force checkout for ${entry.student.firstName} ${entry.student.lastName}`}
                           >
                             Force Out
                           </Button>
@@ -758,6 +767,36 @@ export default function DailyReview() {
               )}
             </tbody>
           </table>
+        </div>
+
+        {/* Mobile Card View (below md breakpoint) */}
+        <div className="block md:hidden" role="list" aria-label="Daily time entries">
+          {loading ? (
+            <div className="bg-white rounded-lg shadow-md p-6 text-center text-gray-500">
+              Loading...
+            </div>
+          ) : filteredEntries.length === 0 ? (
+            <div className="bg-white rounded-lg shadow-md p-6 text-center text-gray-500">
+              {searchTerm || statusFilter !== 'all'
+                ? 'No entries match your filters'
+                : 'No entries for this date'}
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {filteredEntries.map(entry => (
+                <TimeEntryCard
+                  key={entry.id}
+                  entry={entry}
+                  formatTime={formatTime}
+                  formatHours={formatHours}
+                  getStatusDisplay={getStatusDisplay}
+                  getStatusClass={getStatusClass}
+                  onEdit={openEditModal}
+                  onForceCheckout={openForceCheckoutModal}
+                />
+              ))}
+            </div>
+          )}
         </div>
 
         {/* Actions */}


### PR DESCRIPTION
## Summary
Implements a responsive dual-view layout for the DailyReview component that displays a desktop table view on medium screens and above, and a mobile-friendly card view on smaller screens. This improves usability on mobile devices while maintaining the full-featured table interface on desktop.

## Key Changes

- **New TimeEntryCard Component**: Created a mobile-optimized card component (`TimeEntryCard.jsx`) that displays time entry information in a compact, touch-friendly format with proper accessibility attributes
- **Responsive Layout**: Modified DailyReview to render both table and card views simultaneously, using Tailwind's responsive classes (`hidden md:block` and `block md:hidden`) to show/hide based on screen size
- **Accessibility Improvements**: 
  - Added `role="table"` and `aria-label` to the desktop table
  - Added `scope="col"` attributes to all table headers
  - Added `role="list"` and `aria-label` to the mobile card container
  - Added descriptive `aria-label` attributes to action buttons
  - Implemented proper semantic HTML with `<article>` elements for cards
- **Enhanced Test Coverage**: Added comprehensive test suites for:
  - Mobile responsive layout verification
  - Accessibility compliance
  - TimeEntryCard component functionality and edge cases
  - Updated existing tests to account for dual empty state messages

## Implementation Details

- Both views share the same data filtering and state management logic
- Mobile cards display all essential information (name, activity, times, hours, status) in a compact grid layout
- Status indicators and action buttons are context-aware (e.g., "Force Out" only shows when no checkout time)
- Proper handling of edge cases like missing activities, zero hours, and forced checkouts
- Maintains feature parity between desktop and mobile views (edit, force checkout functionality)

https://claude.ai/code/session_01GnaYfbNQUPQRYqfj1UHF3v