### PR TITLE
Restructure admin navigation workspaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,9 @@ This is a web-based volunteer hour tracking system for VBS (Vacation Bible Schoo
 ## Guidelines & Rules
 
 > [!IMPORTANT]
+> **Git Workflow**: ALWAYS create a new branch and open a PR for any code changes. Never commit directly to `main`.
+
+> [!IMPORTANT]
 > **Testing Requirement**: New implementations must **ALWAYS** run unit tests, write new unit tests, and write E2E tests.
 
 ### Common Pitfalls

--- a/firestore.rules
+++ b/firestore.rules
@@ -60,5 +60,10 @@ service cloud.firestore {
     match /pdfTemplates/{templateId} {
       allow read, write: if isAdmin();
     }
+
+    // Settings: Admin only
+    match /settings/{settingId} {
+      allow read, write: if isAdmin();
+    }
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate, Outlet, Link, useLocation } from 'react-router-dom';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { EventProvider } from './contexts/EventContext';
+import Header from './components/common/Header';
 
 // Pages
 import LoginPage from './pages/LoginPage';
@@ -91,6 +92,62 @@ function DefaultRedirect() {
   return canAccessAdmin() ? <Navigate to="/admin" /> : <Navigate to="/scan" />;
 }
 
+function AdminLayout() {
+  return (
+    <div className="min-h-screen bg-gray-50 lg:flex">
+      <Header />
+      <main className="min-w-0 flex-1 lg:pl-72">
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+
+function SettingsLayout() {
+  const location = useLocation();
+  const tabs = [
+    { path: '/admin/settings/events', label: 'Events' },
+    { path: '/admin/settings/users', label: 'Users' },
+    { path: '/admin/settings/pdf-templates', label: 'PDF Templates' },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <h1 className="text-3xl font-black tracking-tight text-gray-900">Settings</h1>
+          <p className="mt-1 text-sm font-medium text-gray-500">
+            Configure events, access, and document templates.
+          </p>
+        </div>
+
+        <div className="mb-6 border-b border-gray-200">
+          <nav className="-mb-px flex gap-1 overflow-x-auto" aria-label="Settings sections">
+            {tabs.map((tab) => {
+              const active = location.pathname.startsWith(tab.path);
+              return (
+                <Link
+                  key={tab.path}
+                  to={tab.path}
+                  className={`whitespace-nowrap border-b-2 px-4 py-3 text-sm font-bold transition-colors ${
+                    active
+                      ? 'border-primary-600 text-primary-700'
+                      : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-900'
+                  }`}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+
+        <Outlet />
+      </div>
+    </div>
+  );
+}
+
 function App() {
   return (
     <Router>
@@ -115,74 +172,26 @@ function App() {
               path="/admin"
               element={
                 <AdminRoute>
-                  <AdminDashboardPage />
+                  <AdminLayout />
                 </AdminRoute>
               }
-            />
-            <Route
-              path="/admin/daily-review"
-              element={
-                <AdminRoute>
-                  <DailyReviewPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/admin/forms"
-              element={
-                <AdminRoute>
-                  <FormGenerationPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/admin/students"
-              element={
-                <AdminRoute>
-                  <StudentsPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/admin/students/:studentId"
-              element={
-                <AdminRoute>
-                  <StudentDetailPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/admin/events"
-              element={
-                <AdminRoute>
-                  <EventsPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/admin/events/new"
-              element={
-                <AdminRoute>
-                  <CreateEventPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/admin/users"
-              element={
-                <AdminRoute>
-                  <UsersPage />
-                </AdminRoute>
-              }
-            />
-            <Route
-              path="/admin/settings/pdf-templates"
-              element={
-                <AdminRoute>
-                  <PdfTemplatesPage />
-                </AdminRoute>
-              }
-            />
+            >
+              <Route index element={<AdminDashboardPage />} />
+              <Route path="daily-review" element={<DailyReviewPage />} />
+              <Route path="forms" element={<FormGenerationPage />} />
+              <Route path="students" element={<StudentsPage />} />
+              <Route path="students/:studentId" element={<StudentDetailPage />} />
+              <Route path="events" element={<Navigate to="/admin/settings/events" replace />} />
+              <Route path="events/new" element={<Navigate to="/admin/settings/events/new" replace />} />
+              <Route path="users" element={<Navigate to="/admin/settings/users" replace />} />
+              <Route path="settings" element={<SettingsLayout />}>
+                <Route index element={<Navigate to="events" replace />} />
+                <Route path="events" element={<EventsPage />} />
+                <Route path="events/new" element={<CreateEventPage />} />
+                <Route path="users" element={<UsersPage />} />
+                <Route path="pdf-templates" element={<PdfTemplatesPage />} />
+              </Route>
+            </Route>
 
             {/* Default Route - redirect based on role */}
             <Route path="/" element={<DefaultRedirect />} />

--- a/frontend/src/components/AdminDashboard/index.jsx
+++ b/frontend/src/components/AdminDashboard/index.jsx
@@ -3,7 +3,6 @@ import { db } from '../../utils/firebase'; //
 import { collection, onSnapshot } from 'firebase/firestore'; //
 import { useEvent } from '../../contexts/EventContext'; // Add this
 import { useTimeEntries } from '../../hooks/useTimeEntries'; // Add this
-import Header from '../common/Header';
 
 /**
  * Admin Dashboard Component
@@ -98,8 +97,6 @@ export default function AdminDashboard() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
-
       <div className="max-w-7xl mx-auto px-4 py-8">
 
         {/* Today's Overview */}

--- a/frontend/src/components/DailyReview/index.jsx
+++ b/frontend/src/components/DailyReview/index.jsx
@@ -6,7 +6,6 @@ import { useEvent } from '../../contexts/EventContext';
 import { formatTime, formatHours, getTodayDateString, formatDate } from '../../utils/hourCalculations';
 import { buildEditChangeDescription } from '../../utils/changeDescriptions';
 import { printInNewWindow, createPrintDocument } from '../../utils/printUtils';
-import Header from '../common/Header';
 import Button from '../common/Button';
 import Modal from '../common/Modal';
 import TimeEntryCard from './TimeEntryCard';
@@ -668,7 +667,6 @@ export default function DailyReview() {
   if (!currentEvent) {
     return (
       <div className="min-h-screen bg-gray-50">
-        <Header />
         <div className="p-4 flex items-center justify-center min-h-[60vh]">
           <div className="text-center text-gray-500">
             <p className="text-lg">No event selected</p>
@@ -681,8 +679,6 @@ export default function DailyReview() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
-
       <div className="max-w-7xl mx-auto px-4 py-6">
         {/* Page Content Header */}
         <div className="bg-white rounded-lg shadow-md p-6 mb-4">

--- a/frontend/src/components/FormGeneration/index.jsx
+++ b/frontend/src/components/FormGeneration/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Header from '../common/Header';
 import Button from '../common/Button';
 
 /**
@@ -13,7 +12,6 @@ import Button from '../common/Button';
 export default function FormGeneration() {
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <div className="max-w-7xl mx-auto px-4 py-6">
         {/* Page Header */}
         <div className="bg-white rounded-lg shadow-md p-6 mb-4">

--- a/frontend/src/components/Scanner/index.jsx
+++ b/frontend/src/components/Scanner/index.jsx
@@ -278,8 +278,9 @@ export default function Scanner() {
   const actionColor = urlAction === 'checkout' ? 'red' : 'green';
 
   return (
-    <div className="min-h-screen bg-gray-50 p-4">
-      <div className="max-w-2xl mx-auto">
+    <div className="min-h-screen bg-gray-50">
+      <ScannerHeader />
+      <div className="max-w-2xl mx-auto p-4">
         <div className="bg-white rounded-lg shadow-md p-6 mb-4 border-t-4 border-primary-600">
           <div className="flex justify-between items-center">
             <div>

--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -2,18 +2,12 @@ import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useEvent } from '../../contexts/EventContext';
-import Button from './Button';
 
 /**
- * Reusable Header Component for Admin Pages
- * Provides consistent navigation and branding across the application
- * Features responsive design with hamburger menu on mobile
+ * Admin workspace chrome.
  *
- * @param {Object} props
- * @param {string} props.title - Optional page title to display (overrides default)
- * @param {boolean} props.showNavTabs - Whether to show navigation tabs (default: true)
- * @param {boolean} props.showEventIndicator - Whether to show active event (default: true)
- * @param {React.ReactNode} props.actions - Optional action buttons to display in header
+ * The selected event anchors the operational navigation, while system-wide
+ * configuration lives in a secondary settings group.
  */
 export default function Header({
   title,
@@ -22,7 +16,11 @@ export default function Header({
   actions,
 }) {
   const { user, signOut } = useAuth();
-  const { currentEvent } = useEvent();
+  const {
+    currentEvent,
+    events = [],
+    switchActiveEvent,
+  } = useEvent();
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -31,206 +29,200 @@ export default function Header({
     await signOut();
   };
 
-  const toggleMobileMenu = () => {
-    setMobileMenuOpen(!mobileMenuOpen);
+  const handleEventChange = async (eventId) => {
+    if (!eventId || eventId === currentEvent?.id) return;
+    await switchActiveEvent(eventId);
   };
 
-  const closeMobileMenu = () => {
+  const closeMenus = () => {
     setMobileMenuOpen(false);
   };
 
-  // Navigation tabs configuration
-  const navTabs = [
+  const operationsNav = [
     { path: '/admin', label: 'Dashboard', exact: true },
-    { path: '/admin/daily-review', label: 'Daily Review' },
     { path: '/admin/students', label: 'Students' },
-    { path: '/admin/events', label: 'Events' },
-    { path: '/admin/users', label: 'Users' },
-    { path: '/admin/settings/pdf-templates', label: 'PDF Templates' },
+    { path: '/admin/daily-review', label: 'Daily Review' },
   ];
 
-  // Check if a tab is active
-  const isTabActive = (tab) => {
-    if (tab.exact) {
-      return location.pathname === tab.path;
-    }
-    return location.pathname.startsWith(tab.path);
+  const settingsLink = { path: '/admin/settings', label: 'Settings' };
+
+  const isActive = (item) => {
+    if (item.exact) return location.pathname === item.path;
+    return location.pathname.startsWith(item.path);
   };
 
-  // Check if scan page is active
-  const isScanActive = location.pathname.startsWith('/scan');
+  const isSettingsActive = location.pathname.startsWith('/admin/settings');
+  const eventLabel = currentEvent?.name || 'No Event Selected';
+  const switcherEvents = currentEvent && !events.some(event => event.id === currentEvent.id)
+    ? [currentEvent, ...events]
+    : events;
+
+  const EventSwitcher = ({ compact = false }) => (
+    <div>
+      <label
+        htmlFor={compact ? 'mobile-event-switcher' : 'desktop-event-switcher'}
+        className="block text-[10px] font-black uppercase tracking-widest text-gray-400"
+      >
+        Active Event
+      </label>
+      <select
+        id={compact ? 'mobile-event-switcher' : 'desktop-event-switcher'}
+        value={currentEvent?.id || ''}
+        onChange={(event) => handleEventChange(event.target.value)}
+        className="mt-1 w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-bold text-gray-900 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+        aria-label="Active Event"
+      >
+        {!currentEvent && <option value="">No Event Selected</option>}
+        {switcherEvents.map((event) => (
+          <option key={event.id} value={event.id}>
+            {event.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+
+  const NavLink = ({ item, mobile = false }) => (
+    <Link
+      to={item.path}
+      onClick={closeMenus}
+      className={`flex items-center rounded-lg px-3 py-2 text-sm font-bold transition-colors ${
+        isActive(item)
+          ? 'bg-primary-50 text-primary-700'
+          : 'text-gray-600 hover:bg-gray-100 hover:text-gray-950'
+      } ${mobile ? 'text-base' : ''}`}
+    >
+      {item.label}
+    </Link>
+  );
 
   return (
-    <header className="bg-white shadow-sm border-b">
-      <div className="max-w-7xl mx-auto px-4 py-4">
-        {/* Top Row: Title, Event Indicator, User Info */}
-        <div className="flex items-center justify-between">
-          {/* Left: Mobile Hamburger Menu Button + App Title */}
-          <div className="flex items-center gap-3">
-            {/* Hamburger Menu Button - Mobile Only */}
-            {showNavTabs && (
-              <button
-                type="button"
-                className="md:hidden p-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
-                onClick={toggleMobileMenu}
-                aria-expanded={mobileMenuOpen}
-                aria-controls="mobile-menu"
-                aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
-              >
-                {mobileMenuOpen ? (
-                  // X icon for close
-                  <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" aria-hidden="true">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                ) : (
-                  // Hamburger icon
-                  <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" aria-hidden="true">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-                  </svg>
-                )}
-              </button>
-            )}
-            <Link to="/admin" className="text-2xl font-bold text-gray-900 hover:text-primary-600 transition-colors">
+    <>
+      <header className="sticky top-0 z-40 border-b border-gray-200 bg-white lg:hidden">
+        <div className="px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <button
+              type="button"
+              className="rounded-md p-2 text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
+              onClick={() => setMobileMenuOpen((open) => !open)}
+              aria-expanded={mobileMenuOpen}
+              aria-controls="mobile-menu"
+              aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
+            >
+              {mobileMenuOpen ? (
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              ) : (
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+              )}
+            </button>
+
+            <Link to="/admin" className="min-w-0 flex-1 truncate text-lg font-black text-gray-950">
               {title || 'VBS Volunteer Tracker'}
             </Link>
+
+            {actions}
+            <Link
+              to="/scan"
+              onClick={closeMenus}
+              className="rounded-lg bg-primary-600 px-3 py-2 text-center text-xs font-black text-white shadow-sm transition-colors hover:bg-primary-700"
+            >
+              Scan
+            </Link>
           </div>
 
-          {/* Center: Active Event Indicator + User Email */}
           {showEventIndicator && (
-            <div className="hidden md:flex flex-col items-center">
-              <div className="flex items-center gap-2">
-                <span className="flex h-2 w-2 rounded-full bg-green-500"></span>
-                <span className="text-sm font-medium text-gray-600">
-                  Active Event: <span className="text-primary-600">{currentEvent?.name || 'No Event Selected'}</span>
-                </span>
-              </div>
-              <span className="text-gray-500 text-xs">{user?.email}</span>
+            <div className="mt-2 flex items-center gap-2 text-xs font-medium text-gray-600">
+              <span className="flex h-2 w-2 rounded-full bg-green-500"></span>
+              Active Event: <span className="font-bold text-primary-700">{eventLabel}</span>
             </div>
           )}
-
-          {/* Right: Scan Button + Logout Button */}
-          <div className="flex items-center gap-2">
-            {actions}
-            {/* Scan Button - styled as app switcher */}
-            <Link
-              to="/scan"
-              className={`hidden sm:inline-flex text-xs font-bold px-3 py-1.5 rounded-lg transition-colors ${
-                isScanActive
-                  ? 'text-white bg-primary-600 hover:bg-primary-700'
-                  : 'text-primary-600 bg-primary-50 hover:bg-primary-100'
-              }`}
-            >
-              Scan
-            </Link>
-            {/* Logout Button - same style as Scan but gray */}
-            <button
-              onClick={handleSignOut}
-              className="hidden sm:inline-flex text-xs font-bold text-gray-600 bg-gray-100 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors"
-            >
-              Logout
-            </button>
-            {/* Mobile logout - only when hamburger menu is not shown */}
-            <div className="sm:hidden">
-              {!showNavTabs && (
-                <button
-                  onClick={handleSignOut}
-                  className="text-xs font-bold text-gray-600 bg-gray-100 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors"
-                >
-                  Logout
-                </button>
-              )}
-            </div>
-          </div>
         </div>
 
-        {/* Mobile Event Indicator */}
-        {showEventIndicator && (
-          <div className="md:hidden flex items-center gap-2 mt-2">
-            <span className="flex h-2 w-2 rounded-full bg-green-500"></span>
-            <span className="text-xs font-medium text-gray-600">
-              Active: <span className="text-primary-600">{currentEvent?.name || 'None'}</span>
-            </span>
-          </div>
-        )}
-      </div>
+        {showNavTabs && mobileMenuOpen && (
+          <div id="mobile-menu" className="border-t border-gray-100 px-4 py-4">
+            <EventSwitcher compact />
 
-      {/* Mobile Menu */}
-      {showNavTabs && mobileMenuOpen && (
-        <div
-          id="mobile-menu"
-          className="md:hidden bg-white border-t border-gray-100"
-        >
-          <div className="px-4 py-3 space-y-1">
-            {/* User info in mobile menu */}
-            <div className="px-3 py-2 border-b border-gray-100 mb-2">
-              <span className="text-sm text-gray-600">{user?.email}</span>
+            <nav className="mt-4 space-y-1" aria-label="Operations">
+              {operationsNav.map((item) => (
+                <NavLink key={item.path} item={item} mobile />
+              ))}
+            </nav>
+
+            <div className="mt-4 border-t border-gray-100 pt-4">
+              <NavLink item={settingsLink} mobile />
             </div>
 
-            {/* Navigation Links */}
-            {navTabs.map((tab) => (
-              <Link
-                key={tab.path}
-                to={tab.path}
-                onClick={closeMobileMenu}
-                className={`block px-3 py-2 rounded-md text-base font-medium transition-colors ${
-                  isTabActive(tab)
-                    ? 'bg-primary-50 text-primary-600'
-                    : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                }`}
-              >
-                {tab.label}
-              </Link>
-            ))}
-
-            {/* Divider before app switcher */}
-            <div className="border-t border-gray-100 my-2"></div>
-
-            {/* Scan Button in Mobile Menu - styled as app switcher */}
-            <Link
-              to="/scan"
-              onClick={closeMobileMenu}
-              className={`block mx-3 px-3 py-2 rounded-lg text-center text-base font-bold transition-colors ${
-                isScanActive
-                  ? 'text-white bg-primary-600'
-                  : 'text-primary-600 bg-primary-50 hover:bg-primary-100'
-              }`}
-            >
-              Scan
-            </Link>
-
-            {/* Logout Button in Mobile Menu - styled like Scan but gray */}
-            <div className="mx-3">
+            <div className="mt-4 border-t border-gray-100 pt-4">
+              <p className="px-3 pb-2 text-sm text-gray-500">{user?.email}</p>
               <button
                 onClick={handleSignOut}
-                className="w-full px-3 py-2 rounded-lg text-center text-base font-bold text-gray-600 bg-gray-100 hover:bg-gray-200 transition-colors"
+                className="w-full rounded-lg bg-gray-100 px-3 py-2 text-center text-base font-bold text-gray-700 transition-colors hover:bg-gray-200"
               >
                 Logout
               </button>
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </header>
 
-      {/* Desktop Navigation Tabs */}
-      {showNavTabs && (
-        <div className="hidden md:block max-w-7xl mx-auto px-4">
-          <div className="flex gap-1 overflow-x-auto border-t border-gray-100 pt-2 pb-0 -mb-px">
-            {navTabs.map((tab) => (
-              <Link
-                key={tab.path}
-                to={tab.path}
-                className={`px-4 py-2 font-medium text-sm whitespace-nowrap transition-colors ${
-                  isTabActive(tab)
-                    ? 'text-primary-600 border-b-2 border-primary-600'
-                    : 'text-gray-600 hover:text-gray-900 border-b-2 border-transparent'
-                }`}
-              >
-                {tab.label}
-              </Link>
-            ))}
+      <aside className="fixed inset-y-0 left-0 z-30 hidden w-72 border-r border-gray-200 bg-white lg:flex lg:flex-col">
+        <div className="border-b border-gray-100 p-5">
+          <Link to="/admin" className="block text-xl font-black text-gray-950 hover:text-primary-700">
+            {title || 'VBS Volunteer Tracker'}
+          </Link>
+          {showEventIndicator && (
+            <p className="mt-1 text-xs text-gray-500">{user?.email}</p>
+          )}
+
+          <div className="mt-5">
+            <EventSwitcher />
           </div>
         </div>
-      )}
-    </header>
+
+        {showNavTabs && (
+          <nav className="flex-1 space-y-1 overflow-y-auto p-4" aria-label="Operations">
+            <p className="px-3 pb-2 text-[10px] font-black uppercase tracking-widest text-gray-400">
+              Operations
+            </p>
+            {operationsNav.map((item) => (
+              <NavLink key={item.path} item={item} />
+            ))}
+          </nav>
+        )}
+
+        <div className="border-t border-gray-100 p-4">
+          <Link
+            to="/admin/settings"
+            onClick={closeMenus}
+            className={`flex w-full items-center rounded-lg px-3 py-2 text-sm font-bold transition-colors ${
+              isSettingsActive
+                ? 'bg-gray-100 text-gray-950'
+                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-950'
+            }`}
+          >
+            ⚙️ Settings
+          </Link>
+
+          <Link
+            to="/scan"
+            onClick={closeMenus}
+            className="mt-3 flex w-full items-center justify-center rounded-lg bg-primary-600 px-3 py-2 text-sm font-black text-white shadow-sm transition-colors hover:bg-primary-700"
+          >
+            Scan
+          </Link>
+
+          <button
+            onClick={handleSignOut}
+            className="mt-3 w-full rounded-lg bg-gray-100 px-3 py-2 text-center text-sm font-bold text-gray-700 transition-colors hover:bg-gray-200"
+          >
+            Logout
+          </button>
+        </div>
+      </aside>
+    </>
   );
 }

--- a/frontend/src/components/common/Header.test.jsx
+++ b/frontend/src/components/common/Header.test.jsx
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import Header from './Header';
 
-// Mock AuthContext
 const mockSignOut = vi.fn();
+const mockSwitchActiveEvent = vi.fn();
 const mockUser = { email: 'admin@test.com', uid: 'admin123' };
+const mockCurrentEvent = { id: 'event123', name: 'VBS 2026' };
+const mockEvents = [
+  mockCurrentEvent,
+  { id: 'event2025', name: 'VBS 2025' },
+];
 
 vi.mock('../../contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -15,16 +20,14 @@ vi.mock('../../contexts/AuthContext', () => ({
   }),
 }));
 
-// Mock EventContext
-const mockCurrentEvent = { id: 'event123', name: 'VBS 2026' };
-
 vi.mock('../../contexts/EventContext', () => ({
   useEvent: () => ({
     currentEvent: mockCurrentEvent,
+    events: mockEvents,
+    switchActiveEvent: mockSwitchActiveEvent,
   }),
 }));
 
-// Helper to render with router
 const renderWithRouter = (ui, { route = '/admin' } = {}) => {
   return render(
     <MemoryRouter initialEntries={[route]}>
@@ -38,340 +41,122 @@ describe('Header', () => {
     vi.clearAllMocks();
   });
 
-  describe('rendering', () => {
-    it('should render the app title', () => {
-      renderWithRouter(<Header />);
-      expect(screen.getByText('VBS Volunteer Tracker')).toBeInTheDocument();
-    });
+  it('renders the admin workspace shell', () => {
+    renderWithRouter(<Header />);
 
-    it('should render custom title when provided', () => {
-      renderWithRouter(<Header title="Custom Title" />);
-      expect(screen.getByText('Custom Title')).toBeInTheDocument();
-    });
-
-    it('should render active event indicator', () => {
-      renderWithRouter(<Header />);
-      // Event name appears in both desktop and mobile views
-      const eventNames = screen.getAllByText('VBS 2026');
-      expect(eventNames.length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText(/Active Event:/)).toBeInTheDocument();
-    });
-
-    it('should display event indicator with the mocked event', () => {
-      // This test verifies the default mocked event is rendered
-      // Testing null event would require module reset which is complex in Vitest
-      renderWithRouter(<Header />);
-
-      // Verify the mocked event is displayed
-      const eventNames = screen.getAllByText('VBS 2026');
-      expect(eventNames.length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('should render user email', () => {
-      renderWithRouter(<Header />);
-      // User email appears in desktop header and mobile menu
-      const userEmails = screen.getAllByText('admin@test.com');
-      expect(userEmails.length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('should render logout button', () => {
-      renderWithRouter(<Header />);
-      // Multiple logout buttons for responsive design (desktop and mobile menu)
-      const logoutButtons = screen.getAllByRole('button', { name: /logout/i });
-      expect(logoutButtons.length).toBeGreaterThanOrEqual(1);
-    });
+    expect(screen.getAllByRole('link', { name: 'VBS Volunteer Tracker' }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole('combobox', { name: 'Active Event' }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('VBS 2026').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Operations')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /settings/i })).toHaveAttribute('href', '/admin/settings');
   });
 
-  describe('navigation tabs', () => {
-    it('should render all navigation tabs by default', () => {
-      renderWithRouter(<Header />);
-
-      // Desktop navigation links (there may be duplicates in mobile menu)
-      expect(screen.getAllByRole('link', { name: 'Dashboard' }).length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByRole('link', { name: 'Daily Review' }).length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByRole('link', { name: 'Students' }).length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByRole('link', { name: 'Events' }).length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByRole('link', { name: 'Users' }).length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('should hide navigation tabs when showNavTabs is false', () => {
-      renderWithRouter(<Header showNavTabs={false} />);
-
-      // Dashboard link should still exist in title, but Daily Review should not
-      expect(screen.queryByRole('link', { name: 'Daily Review' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'Students' })).not.toBeInTheDocument();
-    });
-
-    it('should have correct hrefs for navigation tabs', () => {
-      renderWithRouter(<Header />);
-
-      // Check that at least one link has correct href for each nav item
-      const dashboardLinks = screen.getAllByRole('link', { name: 'Dashboard' });
-      expect(dashboardLinks.some(link => link.getAttribute('href') === '/admin')).toBe(true);
-
-      const dailyReviewLinks = screen.getAllByRole('link', { name: 'Daily Review' });
-      expect(dailyReviewLinks.some(link => link.getAttribute('href') === '/admin/daily-review')).toBe(true);
-
-      const studentsLinks = screen.getAllByRole('link', { name: 'Students' });
-      expect(studentsLinks.some(link => link.getAttribute('href') === '/admin/students')).toBe(true);
-
-      const eventsLinks = screen.getAllByRole('link', { name: 'Events' });
-      expect(eventsLinks.some(link => link.getAttribute('href') === '/admin/events')).toBe(true);
-
-      const usersLinks = screen.getAllByRole('link', { name: 'Users' });
-      expect(usersLinks.some(link => link.getAttribute('href') === '/admin/users')).toBe(true);
-    });
-
-    it('should highlight active Dashboard tab on /admin route', () => {
-      renderWithRouter(<Header />, { route: '/admin' });
-
-      // Check desktop nav link (has border styling)
-      const dashboardLinks = screen.getAllByRole('link', { name: 'Dashboard' });
-      const desktopLink = dashboardLinks.find(link => link.classList.contains('border-b-2'));
-      expect(desktopLink).toHaveClass('text-primary-600');
-      expect(desktopLink).toHaveClass('border-primary-600');
-    });
-
-    it('should highlight active Students tab on /admin/students route', () => {
-      renderWithRouter(<Header />, { route: '/admin/students' });
-
-      const studentsLinks = screen.getAllByRole('link', { name: 'Students' });
-      // At least one should have the active styling
-      expect(studentsLinks.some(link => link.classList.contains('text-primary-600'))).toBe(true);
-    });
-
-    it('should highlight active Daily Review tab on /admin/daily-review route', () => {
-      renderWithRouter(<Header />, { route: '/admin/daily-review' });
-
-      const dailyReviewLinks = screen.getAllByRole('link', { name: 'Daily Review' });
-      expect(dailyReviewLinks.some(link => link.classList.contains('text-primary-600'))).toBe(true);
-    });
+  it('renders custom title when provided', () => {
+    renderWithRouter(<Header title="Custom Title" />);
+    expect(screen.getAllByRole('link', { name: 'Custom Title' }).length).toBeGreaterThanOrEqual(1);
   });
 
-  describe('event indicator', () => {
-    it('should hide event indicator when showEventIndicator is false', () => {
-      renderWithRouter(<Header showEventIndicator={false} />);
+  it('keeps operational links separate from settings pages', () => {
+    renderWithRouter(<Header />);
 
-      expect(screen.queryByText(/Active Event:/)).not.toBeInTheDocument();
-    });
-
-    it('should show event indicator when showEventIndicator is true', () => {
-      renderWithRouter(<Header showEventIndicator={true} />);
-
-      expect(screen.getByText(/Active Event:/)).toBeInTheDocument();
-    });
+    expect(screen.getAllByRole('link', { name: 'Dashboard' }).some(link => link.getAttribute('href') === '/admin')).toBe(true);
+    expect(screen.getAllByRole('link', { name: 'Students' }).some(link => link.getAttribute('href') === '/admin/students')).toBe(true);
+    expect(screen.getAllByRole('link', { name: 'Daily Review' }).some(link => link.getAttribute('href') === '/admin/daily-review')).toBe(true);
+    expect(screen.getByRole('link', { name: /settings/i })).toHaveAttribute('href', '/admin/settings');
+    expect(screen.queryByRole('link', { name: 'Events' })).not.toBeInTheDocument();
   });
 
-  describe('actions', () => {
-    it('should render custom actions when provided', () => {
-      const CustomAction = <button>Custom Action</button>;
-      renderWithRouter(<Header actions={CustomAction} />);
+  it('highlights settings when a settings route is active', () => {
+    renderWithRouter(<Header />, { route: '/admin/settings/users' });
 
-      expect(screen.getByRole('button', { name: 'Custom Action' })).toBeInTheDocument();
-    });
+    expect(screen.getByRole('link', { name: /settings/i })).toHaveClass('bg-gray-100');
   });
 
-  describe('logout functionality', () => {
-    it('should call signOut when logout button is clicked', async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<Header />);
+  it('highlights active operational links', () => {
+    renderWithRouter(<Header />, { route: '/admin/students' });
 
-      // Get the first logout button (multiple exist for responsive design)
-      const logoutButtons = screen.getAllByRole('button', { name: /logout/i });
-      await user.click(logoutButtons[0]);
-
-      expect(mockSignOut).toHaveBeenCalledTimes(1);
-    });
+    const studentsLinks = screen.getAllByRole('link', { name: 'Students' });
+    expect(studentsLinks.some(link => link.classList.contains('bg-primary-50'))).toBe(true);
   });
 
-  describe('responsive behavior', () => {
-    it('should render mobile logout button', () => {
-      renderWithRouter(<Header />);
+  it('switches the active event from the context switcher', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<Header />);
 
-      // Both desktop and mobile logout buttons should exist
-      const logoutButtons = screen.getAllByRole('button', { name: /logout/i });
-      expect(logoutButtons.length).toBeGreaterThanOrEqual(1);
-    });
+    await user.selectOptions(screen.getAllByRole('combobox', { name: 'Active Event' })[0], 'event2025');
+
+    expect(mockSwitchActiveEvent).toHaveBeenCalledWith('event2025');
   });
 
-  describe('app title link', () => {
-    it('should link to /admin dashboard', () => {
-      renderWithRouter(<Header />);
+  it('renders the Scan action as the prominent app switcher', () => {
+    renderWithRouter(<Header />);
 
-      const titleLink = screen.getByRole('link', { name: /VBS Volunteer Tracker/i });
-      expect(titleLink).toHaveAttribute('href', '/admin');
-    });
+    const scanLinks = screen.getAllByRole('link', { name: 'Scan' });
+    expect(scanLinks.some(link => link.getAttribute('href') === '/scan')).toBe(true);
+    expect(scanLinks.some(link => link.classList.contains('bg-primary-600'))).toBe(true);
   });
 
-  describe('hamburger menu', () => {
-    it('should render hamburger menu button when showNavTabs is true', () => {
-      renderWithRouter(<Header showNavTabs={true} />);
+  it('hides nav groups when showNavTabs is false', () => {
+    renderWithRouter(<Header showNavTabs={false} />);
 
-      const menuButton = screen.getByRole('button', { name: /open menu/i });
-      expect(menuButton).toBeInTheDocument();
-    });
+    expect(screen.queryByRole('link', { name: 'Daily Review' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Students' })).not.toBeInTheDocument();
+  });
 
-    it('should not render hamburger menu button when showNavTabs is false', () => {
-      renderWithRouter(<Header showNavTabs={false} />);
+  it('hides event indicator text when showEventIndicator is false', () => {
+    renderWithRouter(<Header showEventIndicator={false} />);
 
-      expect(screen.queryByRole('button', { name: /open menu/i })).not.toBeInTheDocument();
-    });
+    expect(screen.queryByText(/Active Event:/)).not.toBeInTheDocument();
+    expect(screen.queryByText('admin@test.com')).not.toBeInTheDocument();
+  });
 
-    it('should toggle mobile menu when hamburger button is clicked', async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<Header />);
+  it('renders custom actions', () => {
+    renderWithRouter(<Header actions={<button>Custom Action</button>} />);
 
-      // Mobile menu should not be visible initially (no id="mobile-menu" element)
-      expect(screen.queryByRole('button', { name: /close menu/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Custom Action' })).toBeInTheDocument();
+  });
 
-      // Click hamburger to open menu
-      const menuButton = screen.getByRole('button', { name: /open menu/i });
-      await user.click(menuButton);
+  it('signs out from the desktop shell', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<Header />);
 
-      // Close button should now be visible
-      expect(screen.getByRole('button', { name: /close menu/i })).toBeInTheDocument();
+    await user.click(screen.getAllByRole('button', { name: /logout/i })[0]);
 
-      // Click again to close
-      const closeButton = screen.getByRole('button', { name: /close menu/i });
-      await user.click(closeButton);
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+  });
 
-      // Back to open menu button
+  it('toggles and closes the mobile menu', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<Header />);
+
+    await user.click(screen.getByRole('button', { name: /open menu/i }));
+    expect(screen.getByRole('button', { name: /close menu/i })).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(screen.getAllByRole('link', { name: 'Students' })[0]);
+
+    await waitFor(() => {
       expect(screen.getByRole('button', { name: /open menu/i })).toBeInTheDocument();
     });
+  });
 
-    it('should close mobile menu when a navigation link is clicked', async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<Header />);
+  it('closes the mobile menu when Scan is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<Header />);
 
-      // Open the mobile menu
-      const menuButton = screen.getByRole('button', { name: /open menu/i });
-      await user.click(menuButton);
+    await user.click(screen.getByRole('button', { name: /open menu/i }));
+    const mobileScan = screen.getAllByRole('link', { name: 'Scan' }).find(link => link.classList.contains('text-center'));
+    await user.click(mobileScan);
 
-      // Verify menu is open (close button visible)
-      expect(screen.getByRole('button', { name: /close menu/i })).toBeInTheDocument();
-
-      // Click a navigation link in the mobile menu
-      // Mobile menu links have specific styling (rounded-md)
-      const mobileLinks = screen.getAllByRole('link', { name: 'Students' });
-      const mobileLink = mobileLinks.find(link => link.classList.contains('rounded-md'));
-      await user.click(mobileLink);
-
-      // Menu should be closed (back to open menu button)
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /open menu/i })).toBeInTheDocument();
-      });
-    });
-
-    it('should display user email in mobile menu', async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<Header />);
-
-      // Open the mobile menu
-      const menuButton = screen.getByRole('button', { name: /open menu/i });
-      await user.click(menuButton);
-
-      // User email should be visible in mobile menu
-      const userEmails = screen.getAllByText('admin@test.com');
-      expect(userEmails.length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('should call signOut when logout in mobile menu is clicked', async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<Header />);
-
-      // Open the mobile menu
-      const menuButton = screen.getByRole('button', { name: /open menu/i });
-      await user.click(menuButton);
-
-      // Find the mobile menu logout button (text-based, not the Button component)
-      const logoutButtons = screen.getAllByRole('button', { name: /logout/i });
-      // Click the one in mobile menu (should be the last one or the one with specific classes)
-      const mobileLogout = logoutButtons.find(btn => btn.classList.contains('w-full'));
-      await user.click(mobileLogout);
-
-      expect(mockSignOut).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /open menu/i })).toBeInTheDocument();
     });
   });
 
-  describe('scan button', () => {
-    it('should render Scan button in header', () => {
-      renderWithRouter(<Header />);
+  it('wires mobile menu accessibility attributes', () => {
+    renderWithRouter(<Header />);
 
-      const scanLinks = screen.getAllByRole('link', { name: 'Scan' });
-      expect(scanLinks.length).toBeGreaterThanOrEqual(1);
-      expect(scanLinks.some(link => link.getAttribute('href') === '/scan')).toBe(true);
-    });
-
-    it('should render Scan button in mobile menu', async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<Header />);
-
-      // Open mobile menu
-      const menuButton = screen.getByRole('button', { name: /open menu/i });
-      await user.click(menuButton);
-
-      // Find Scan button in mobile menu (styled as button with block and text-center)
-      const scanLinks = screen.getAllByRole('link', { name: 'Scan' });
-      const mobileScanButton = scanLinks.find(link => link.classList.contains('text-center'));
-      expect(mobileScanButton).toBeInTheDocument();
-      expect(mobileScanButton).toHaveAttribute('href', '/scan');
-    });
-
-    it('should highlight Scan button when on /scan route', () => {
-      renderWithRouter(<Header />, { route: '/scan' });
-
-      const scanLinks = screen.getAllByRole('link', { name: 'Scan' });
-      // Active state uses bg-primary-600 (filled button) instead of text-primary-600
-      expect(scanLinks.some(link => link.classList.contains('bg-primary-600'))).toBe(true);
-    });
-
-    it('should highlight Scan button when on /scan/:eventId route', () => {
-      renderWithRouter(<Header />, { route: '/scan/event123' });
-
-      const scanLinks = screen.getAllByRole('link', { name: 'Scan' });
-      // Active state uses bg-primary-600 (filled button)
-      expect(scanLinks.some(link => link.classList.contains('bg-primary-600'))).toBe(true);
-    });
-
-    it('should close mobile menu when Scan button is clicked', async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<Header />);
-
-      // Open mobile menu
-      const menuButton = screen.getByRole('button', { name: /open menu/i });
-      await user.click(menuButton);
-
-      // Click Scan button (mobile version has text-center class)
-      const scanLinks = screen.getAllByRole('link', { name: 'Scan' });
-      const mobileScanButton = scanLinks.find(link => link.classList.contains('text-center'));
-      await user.click(mobileScanButton);
-
-      // Menu should close
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /open menu/i })).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe('accessibility', () => {
-    it('should have aria-expanded attribute on hamburger button', async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<Header />);
-
-      const menuButton = screen.getByRole('button', { name: /open menu/i });
-      expect(menuButton).toHaveAttribute('aria-expanded', 'false');
-
-      await user.click(menuButton);
-
-      const closeButton = screen.getByRole('button', { name: /close menu/i });
-      expect(closeButton).toHaveAttribute('aria-expanded', 'true');
-    });
-
-    it('should have aria-controls attribute pointing to mobile menu', () => {
-      renderWithRouter(<Header />);
-
-      const menuButton = screen.getByRole('button', { name: /open menu/i });
-      expect(menuButton).toHaveAttribute('aria-controls', 'mobile-menu');
-    });
+    const menuButton = screen.getByRole('button', { name: /open menu/i });
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+    expect(menuButton).toHaveAttribute('aria-controls', 'mobile-menu');
   });
 });

--- a/frontend/src/components/common/ScannerHeader.jsx
+++ b/frontend/src/components/common/ScannerHeader.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 
 /**
@@ -10,7 +10,7 @@ import { useAuth } from '../../contexts/AuthContext';
  * to provide a streamlined experience during check-in/check-out operations.
  */
 export default function ScannerHeader() {
-  const { userProfile, signOut, canAccessAdmin } = useAuth();
+  const { signOut, canAccessAdmin } = useAuth();
   const navigate = useNavigate();
 
   const handleSignOut = async () => {
@@ -18,34 +18,29 @@ export default function ScannerHeader() {
     navigate('/login');
   };
 
+  const handleExit = async () => {
+    if (canAccessAdmin()) {
+      navigate('/admin');
+      return;
+    }
+
+    await handleSignOut();
+  };
+
   return (
     <div className="bg-white shadow-sm border-b mb-6">
-      <div className="max-w-md mx-auto px-4 py-3 flex items-center justify-between">
-        {/* Left: User Info & Role Badge */}
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-600">{userProfile?.name || userProfile?.email}</span>
-          <span className="px-2 py-0.5 rounded text-[9px] font-black uppercase bg-blue-100 text-blue-700">
-            {userProfile?.role === 'admin' ? 'Admin' : 'Volunteer'}
-          </span>
+      <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-3">
+        <div>
+          <p className="text-[10px] font-black uppercase tracking-widest text-primary-600">Scan Mode</p>
+          <h1 className="text-sm font-black text-gray-950">VBS Volunteer Tracker</h1>
         </div>
 
-        {/* Right: Navigation & Actions */}
-        <div className="flex items-center gap-2">
-          {canAccessAdmin() && (
-            <Link
-              to="/admin"
-              className="text-xs font-bold text-primary-600 bg-primary-50 px-3 py-1.5 rounded-lg hover:bg-primary-100 transition-colors"
-            >
-              Dashboard
-            </Link>
-          )}
-          <button
-            onClick={handleSignOut}
-            className="text-xs font-bold text-gray-600 bg-gray-100 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors"
-          >
-            Logout
-          </button>
-        </div>
+        <button
+          onClick={handleExit}
+          className="rounded-lg bg-gray-100 px-3 py-2 text-xs font-bold text-gray-700 transition-colors hover:bg-gray-200"
+        >
+          Exit Scan Mode
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/common/ScannerHeader.test.jsx
+++ b/frontend/src/components/common/ScannerHeader.test.jsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import ScannerHeader from './ScannerHeader';
 
-// Mock useNavigate
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -14,20 +13,16 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-// Mock AuthContext - default to admin user
 const mockSignOut = vi.fn().mockResolvedValue(undefined);
-let mockUserProfile = { name: 'Admin User', email: 'admin@test.com', role: 'admin' };
 let mockCanAccessAdmin = vi.fn(() => true);
 
 vi.mock('../../contexts/AuthContext', () => ({
   useAuth: () => ({
-    userProfile: mockUserProfile,
     signOut: mockSignOut,
     canAccessAdmin: mockCanAccessAdmin,
   }),
 }));
 
-// Helper to render with router
 const renderWithRouter = (ui, { route = '/scan' } = {}) => {
   return render(
     <MemoryRouter initialEntries={[route]}>
@@ -39,123 +34,56 @@ const renderWithRouter = (ui, { route = '/scan' } = {}) => {
 describe('ScannerHeader', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUserProfile = { name: 'Admin User', email: 'admin@test.com', role: 'admin' };
     mockCanAccessAdmin = vi.fn(() => true);
   });
 
-  describe('rendering', () => {
-    it('should render user name when available', () => {
-      renderWithRouter(<ScannerHeader />);
-      expect(screen.getByText('Admin User')).toBeInTheDocument();
-    });
+  it('renders kiosk scan mode chrome', () => {
+    renderWithRouter(<ScannerHeader />);
 
-    it('should render user email when name is not available', () => {
-      mockUserProfile = { email: 'user@test.com', role: 'admin' };
-      renderWithRouter(<ScannerHeader />);
-      expect(screen.getByText('user@test.com')).toBeInTheDocument();
-    });
+    expect(screen.getByText('Scan Mode')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'VBS Volunteer Tracker' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Exit Scan Mode' })).toBeInTheDocument();
+  });
 
-    it('should render admin role badge for admin users', () => {
-      mockUserProfile = { name: 'Test User', email: 'admin@test.com', role: 'admin' };
-      renderWithRouter(<ScannerHeader />);
-      // Get the badge by its styling class
-      const badges = screen.getAllByText('Admin');
-      expect(badges.length).toBeGreaterThanOrEqual(1);
-      // Find the one with the badge styling
-      const badge = badges.find(el => el.classList.contains('uppercase'));
-      expect(badge).toBeInTheDocument();
-    });
+  it('does not render admin navigation links or logout controls', () => {
+    renderWithRouter(<ScannerHeader />);
 
-    it('should render volunteer role badge for volunteer users', () => {
-      mockUserProfile = { name: 'Test User', email: 'volunteer@test.com', role: 'adult_volunteer' };
-      renderWithRouter(<ScannerHeader />);
-      // Get the badge by its styling class
-      const badges = screen.getAllByText('Volunteer');
-      expect(badges.length).toBeGreaterThanOrEqual(1);
-      // Find the one with the badge styling
-      const badge = badges.find(el => el.classList.contains('uppercase'));
-      expect(badge).toBeInTheDocument();
-    });
+    expect(screen.queryByRole('link', { name: /dashboard/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /logout/i })).not.toBeInTheDocument();
+  });
 
-    it('should render logout button', () => {
-      renderWithRouter(<ScannerHeader />);
-      expect(screen.getByRole('button', { name: /logout/i })).toBeInTheDocument();
+  it('returns admins to the admin workspace', async () => {
+    const user = userEvent.setup();
+    mockCanAccessAdmin = vi.fn(() => true);
+    renderWithRouter(<ScannerHeader />);
+
+    await user.click(screen.getByRole('button', { name: 'Exit Scan Mode' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/admin');
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('signs non-admin scanner users out on exit', async () => {
+    const user = userEvent.setup();
+    mockCanAccessAdmin = vi.fn(() => false);
+    renderWithRouter(<ScannerHeader />);
+
+    await user.click(screen.getByRole('button', { name: 'Exit Scan Mode' }));
+
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
     });
   });
 
-  describe('admin access', () => {
-    it('should show Dashboard link for admin users', () => {
-      mockCanAccessAdmin = vi.fn(() => true);
-      renderWithRouter(<ScannerHeader />);
-      expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
-    });
+  it('keeps the compact scanner wrapper styling', () => {
+    const { container } = renderWithRouter(<ScannerHeader />);
 
-    it('should hide Dashboard link for non-admin users', () => {
-      mockCanAccessAdmin = vi.fn(() => false);
-      renderWithRouter(<ScannerHeader />);
-      expect(screen.queryByRole('link', { name: /dashboard/i })).not.toBeInTheDocument();
-    });
-
-    it('should link Dashboard to /admin route', () => {
-      mockCanAccessAdmin = vi.fn(() => true);
-      renderWithRouter(<ScannerHeader />);
-
-      const dashboardLink = screen.getByRole('link', { name: /dashboard/i });
-      expect(dashboardLink).toHaveAttribute('href', '/admin');
-    });
-  });
-
-  describe('logout functionality', () => {
-    it('should call signOut when logout button is clicked', async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<ScannerHeader />);
-
-      const logoutButton = screen.getByRole('button', { name: /logout/i });
-      await user.click(logoutButton);
-
-      expect(mockSignOut).toHaveBeenCalledTimes(1);
-    });
-
-    it('should navigate to /login after signOut', async () => {
-      const user = userEvent.setup();
-      renderWithRouter(<ScannerHeader />);
-
-      const logoutButton = screen.getByRole('button', { name: /logout/i });
-      await user.click(logoutButton);
-
-      await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
-      });
-    });
-  });
-
-  describe('styling', () => {
-    it('should have the scanner header wrapper class', () => {
-      const { container } = renderWithRouter(<ScannerHeader />);
-
-      const header = container.firstChild;
-      expect(header).toHaveClass('bg-white');
-      expect(header).toHaveClass('shadow-sm');
-      expect(header).toHaveClass('border-b');
-      expect(header).toHaveClass('mb-6');
-    });
-
-    it('should have role badge styling', () => {
-      renderWithRouter(<ScannerHeader />);
-
-      const badge = screen.getByText('Admin');
-      expect(badge).toHaveClass('bg-blue-100');
-      expect(badge).toHaveClass('text-blue-700');
-      expect(badge).toHaveClass('uppercase');
-    });
-  });
-
-  describe('mobile optimization', () => {
-    it('should have max-width constraint for mobile', () => {
-      const { container } = renderWithRouter(<ScannerHeader />);
-
-      const innerContainer = container.querySelector('.max-w-md');
-      expect(innerContainer).toBeInTheDocument();
-    });
+    const header = container.firstChild;
+    expect(header).toHaveClass('bg-white');
+    expect(header).toHaveClass('shadow-sm');
+    expect(header).toHaveClass('border-b');
+    expect(header).toHaveClass('mb-6');
+    expect(container.querySelector('.max-w-2xl')).toBeInTheDocument();
   });
 });

--- a/frontend/src/contexts/EventContext.jsx
+++ b/frontend/src/contexts/EventContext.jsx
@@ -1,20 +1,32 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { db } from '../utils/firebase';
-import { 
-  collection, 
-  query, 
-  where, 
-  getDocs, 
-  doc, 
-  getDoc, 
-  onSnapshot, 
-  orderBy, 
-  limit, 
-  updateDoc // Added this import
+import {
+  collection,
+  getDocs,
+  doc,
+  getDoc,
+  onSnapshot,
+  updateDoc
 } from 'firebase/firestore';
 import { useAuth } from './AuthContext';
 
 const EventContext = createContext(null);
+
+const getCreatedMillis = (event) => {
+  const createdAt = event.createdAt;
+  if (!createdAt) return 0;
+  if (typeof createdAt.toMillis === 'function') return createdAt.toMillis();
+  if (typeof createdAt.seconds === 'number') return createdAt.seconds * 1000;
+  return new Date(createdAt).getTime() || 0;
+};
+
+const sortEvents = (eventList) => {
+  return [...eventList].sort((a, b) => {
+    const createdDiff = getCreatedMillis(b) - getCreatedMillis(a);
+    if (createdDiff !== 0) return createdDiff;
+    return (b.name || '').localeCompare(a.name || '');
+  });
+};
 
 export function useEvent() {
   const context = useContext(EventContext);
@@ -26,6 +38,7 @@ export function useEvent() {
 
 export function EventProvider({ children }) {
   const [currentEvent, setCurrentEvent] = useState(null);
+  const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const { user } = useAuth();
@@ -53,12 +66,36 @@ export function EventProvider({ children }) {
     return () => unsubscribe();
   }, [user]);
 
+  useEffect(() => {
+    if (!user) {
+      setEvents([]);
+      return;
+    }
+
+    const unsubscribe = onSnapshot(collection(db, 'events'), (snapshot) => {
+      const eventList = snapshot.docs.map(eventDoc => ({
+        id: eventDoc.id,
+        ...eventDoc.data()
+      }));
+      setEvents(sortEvents(eventList));
+    }, (err) => {
+      console.error('Error loading events:', err);
+      setError('Failed to load events');
+    });
+
+    return () => unsubscribe();
+  }, [user]);
+
   /**
    * Updates the Admin's selected event in Firestore
    */
   const switchActiveEvent = async (eventId) => {
     if (!user) return;
     try {
+      const selectedEvent = events.find(event => event.id === eventId);
+      if (selectedEvent) {
+        setCurrentEvent(selectedEvent);
+      }
       const adminRef = doc(db, 'admins', user.uid);
       // This persistent update ensures your selection follows you across devices
       await updateDoc(adminRef, { selectedEventId: eventId });
@@ -69,10 +106,13 @@ export function EventProvider({ children }) {
   };
 
   const loadDefaultEvent = async () => {
-    const q = query(collection(db, 'events'), orderBy('createdAt', 'desc'), limit(1));
-    const snap = await getDocs(q);
+    const snap = await getDocs(collection(db, 'events'));
     if (!snap.empty) {
-      setCurrentEvent({ id: snap.docs[0].id, ...snap.docs[0].data() });
+      const eventList = sortEvents(snap.docs.map(eventDoc => ({
+        id: eventDoc.id,
+        ...eventDoc.data()
+      })));
+      setCurrentEvent(eventList[0]);
     }
   };
 
@@ -106,6 +146,7 @@ export function EventProvider({ children }) {
 
   const value = {
     currentEvent,
+    events,
     loading,
     error,
     loadEventById,

--- a/frontend/src/pages/CreateEventPage.jsx
+++ b/frontend/src/pages/CreateEventPage.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { db } from '../utils/firebase';
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
-import Header from '../components/common/Header';
 import Button from '../components/common/Button';
 import Input from '../components/common/Input';
 
@@ -31,7 +30,7 @@ export default function CreateEventPage() {
       });
 
       console.log("Event created with ID: ", docRef.id);
-      navigate('/admin/events'); // Redirect back to list
+      navigate('/admin/settings/events'); // Redirect back to list
     } catch (err) {
       console.error("Error adding event: ", err);
       alert("Failed to create event. Check console for details.");
@@ -47,7 +46,6 @@ export default function CreateEventPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <div className="p-8">
         <div className="max-w-2xl mx-auto bg-white p-8 rounded-lg shadow-md">
           <h1 className="text-2xl font-bold mb-6 text-gray-900">Create New Volunteer Event</h1>
@@ -72,7 +70,7 @@ export default function CreateEventPage() {
               <Button type="submit" variant="primary" className="w-full" disabled={loading}>
                 {loading ? 'Creating...' : 'Create Event'}
               </Button>
-              <Button type="button" variant="secondary" onClick={() => navigate('/admin/events')}>
+              <Button type="button" variant="secondary" onClick={() => navigate('/admin/settings/events')}>
                 Cancel
               </Button>
             </div>

--- a/frontend/src/pages/EventsPage.jsx
+++ b/frontend/src/pages/EventsPage.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { db } from '../utils/firebase';
 import { collection, onSnapshot, doc, updateDoc, addDoc } from 'firebase/firestore';
 import { useEvent } from '../contexts/EventContext';
-import Header from '../components/common/Header';
 import Spinner from '../components/common/Spinner';
 import Button from '../components/common/Button';
 
@@ -96,14 +95,12 @@ export default function EventsPage() {
 
     if (loading) return (
         <div className="min-h-screen bg-gray-50">
-            <Header />
             <div className="p-20 text-center"><Spinner size="lg" /></div>
         </div>
     );
 
     return (
         <div className="min-h-screen bg-gray-50">
-            <Header />
             <div className="p-6 max-w-7xl mx-auto">
                 {/* PAGE HEADER */}
                 <div className="mb-8">

--- a/frontend/src/pages/PdfTemplatesPage.jsx
+++ b/frontend/src/pages/PdfTemplatesPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { db, storage } from '../utils/firebase';
-import { collection, addDoc, onSnapshot, deleteDoc, doc, updateDoc } from 'firebase/firestore';
+import { collection, addDoc, onSnapshot, deleteDoc, doc, updateDoc, setDoc } from 'firebase/firestore';
 import { ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage';
 import { FIELD_KEY_OPTIONS, ACTIVITY_COLUMN_OPTIONS, DETAIL_COLUMN_OPTIONS, getPdfPageDimensions, renderPdfPageToImage } from '../utils/pdfTemplateUtils';
 import Header from '../components/common/Header';
@@ -10,17 +10,29 @@ import Spinner from '../components/common/Spinner';
 
 export default function PdfTemplatesPage() {
   const [templates, setTemplates] = useState([]);
+  const [defaultTemplateId, setDefaultTemplateId] = useState(null);
   const [loading, setLoading] = useState(true);
   const [uploadModal, setUploadModal] = useState({ isOpen: false });
   const [mapperModal, setMapperModal] = useState({ isOpen: false, template: null });
 
   useEffect(() => {
-    const unsubscribe = onSnapshot(collection(db, 'pdfTemplates'), (snapshot) => {
+    const unsubTemplates = onSnapshot(collection(db, 'pdfTemplates'), (snapshot) => {
       setTemplates(snapshot.docs.map(d => ({ id: d.id, ...d.data() })));
       setLoading(false);
     });
-    return () => unsubscribe();
+    const unsubDefaults = onSnapshot(doc(db, 'settings', 'pdfDefaults'), (snap) => {
+      setDefaultTemplateId(snap.exists() ? snap.data().defaultTemplateId : null);
+    });
+    return () => { unsubTemplates(); unsubDefaults(); };
   }, []);
+
+  const handleSetDefault = async (templateId) => {
+    try {
+      await setDoc(doc(db, 'settings', 'pdfDefaults'), { defaultTemplateId: templateId });
+    } catch (err) {
+      alert('Failed to set default template: ' + err.message);
+    }
+  };
 
   const handleDeleteTemplate = async (template) => {
     if (!window.confirm(`Delete template "${template.name}"? This cannot be undone.`)) return;
@@ -30,6 +42,9 @@ export default function PdfTemplatesPage() {
         await deleteObject(storageRef).catch(() => {});
       }
       await deleteDoc(doc(db, 'pdfTemplates', template.id));
+      if (template.id === defaultTemplateId) {
+        await setDoc(doc(db, 'settings', 'pdfDefaults'), { defaultTemplateId: null });
+      }
     } catch (err) {
       alert('Failed to delete template: ' + err.message);
     }
@@ -65,36 +80,53 @@ export default function PdfTemplatesPage() {
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {templates.map(template => (
-              <div key={template.id} className="bg-white rounded-2xl shadow-sm border p-6">
-                <div className="flex items-start justify-between mb-3">
-                  <h3 className="text-lg font-bold text-gray-900">{template.name}</h3>
-                  <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full">
-                    {(template.fields || []).length} fields
-                  </span>
+            {templates.map(template => {
+              const isDefault = template.id === defaultTemplateId;
+              return (
+                <div key={template.id} className={`bg-white rounded-2xl shadow-sm border p-6 ${isDefault ? 'ring-2 ring-primary-400' : ''}`}>
+                  <div className="flex items-start justify-between mb-3">
+                    <div className="flex items-center gap-2">
+                      <h3 className="text-lg font-bold text-gray-900">{template.name}</h3>
+                      {isDefault && (
+                        <span className="text-xs bg-primary-100 text-primary-700 font-semibold px-2 py-0.5 rounded-full">Default</span>
+                      )}
+                    </div>
+                    <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full">
+                      {(template.fields || []).length} fields
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-500 mb-1">{template.fileName}</p>
+                  <p className="text-xs text-gray-400 mb-4">
+                    {template.pageCount || 1} page{(template.pageCount || 1) > 1 ? 's' : ''}
+                  </p>
+                  <div className="flex gap-2 flex-wrap">
+                    <Button
+                      size="sm"
+                      variant="primary"
+                      onClick={() => setMapperModal({ isOpen: true, template })}
+                    >
+                      Map Fields
+                    </Button>
+                    {!isDefault && (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => handleSetDefault(template.id)}
+                      >
+                        Set as Default
+                      </Button>
+                    )}
+                    <Button
+                      size="sm"
+                      variant="danger"
+                      onClick={() => handleDeleteTemplate(template)}
+                    >
+                      Delete
+                    </Button>
+                  </div>
                 </div>
-                <p className="text-sm text-gray-500 mb-1">{template.fileName}</p>
-                <p className="text-xs text-gray-400 mb-4">
-                  {template.pageCount || 1} page{(template.pageCount || 1) > 1 ? 's' : ''}
-                </p>
-                <div className="flex gap-2">
-                  <Button
-                    size="sm"
-                    variant="primary"
-                    onClick={() => setMapperModal({ isOpen: true, template })}
-                  >
-                    Map Fields
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="danger"
-                    onClick={() => handleDeleteTemplate(template)}
-                  >
-                    Delete
-                  </Button>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
 

--- a/frontend/src/pages/PdfTemplatesPage.jsx
+++ b/frontend/src/pages/PdfTemplatesPage.jsx
@@ -3,7 +3,6 @@ import { db, storage } from '../utils/firebase';
 import { collection, addDoc, onSnapshot, deleteDoc, doc, updateDoc, setDoc } from 'firebase/firestore';
 import { ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage';
 import { FIELD_KEY_OPTIONS, ACTIVITY_COLUMN_OPTIONS, DETAIL_COLUMN_OPTIONS, getPdfPageDimensions, renderPdfPageToImage } from '../utils/pdfTemplateUtils';
-import Header from '../components/common/Header';
 import Button from '../components/common/Button';
 import Modal from '../components/common/Modal';
 import Spinner from '../components/common/Spinner';
@@ -53,7 +52,6 @@ export default function PdfTemplatesPage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50">
-        <Header />
         <div className="p-20 text-center"><Spinner size="lg" /></div>
       </div>
     );
@@ -61,7 +59,6 @@ export default function PdfTemplatesPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <div className="max-w-5xl mx-auto p-6">
         <div className="flex justify-between items-center mb-8">
           <div>

--- a/frontend/src/pages/PdfTemplatesPage.test.jsx
+++ b/frontend/src/pages/PdfTemplatesPage.test.jsx
@@ -11,19 +11,26 @@ vi.mock('../utils/firebase', () => ({
 }));
 
 // Track onSnapshot callbacks for programmatic updates
-let onSnapshotCallback = null;
+let onSnapshotTemplatesCallback = null;
 
 vi.mock('firebase/firestore', () => ({
-  collection: vi.fn(),
+  collection: vi.fn((db, path) => ({ _collPath: path })),
   addDoc: vi.fn(() => Promise.resolve({ id: 'new-template-id' })),
-  onSnapshot: vi.fn((query, callback) => {
-    onSnapshotCallback = callback;
-    callback({ docs: [] });
+  onSnapshot: vi.fn((queryOrRef, callback) => {
+    if (queryOrRef?._isDoc) {
+      // Document snapshot (settings/pdfDefaults)
+      callback({ exists: () => false, data: () => null });
+    } else {
+      // Collection snapshot (pdfTemplates)
+      onSnapshotTemplatesCallback = callback;
+      callback({ docs: [] });
+    }
     return vi.fn();
   }),
   deleteDoc: vi.fn(() => Promise.resolve()),
-  doc: vi.fn(() => ({ id: 'template1' })),
+  doc: vi.fn(() => ({ _isDoc: true, id: 'template1' })),
   updateDoc: vi.fn(() => Promise.resolve()),
+  setDoc: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock('firebase/storage', () => ({
@@ -84,7 +91,7 @@ const renderPage = () => {
 
 const simulateTemplates = async (docs) => {
   await act(async () => {
-    onSnapshotCallback({ docs });
+    onSnapshotTemplatesCallback({ docs });
   });
 };
 
@@ -96,7 +103,7 @@ const makeTemplateDoc = (id, data) => ({
 describe('PdfTemplatesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    onSnapshotCallback = null;
+    onSnapshotTemplatesCallback = null;
   });
 
   afterEach(() => {
@@ -416,6 +423,53 @@ describe('PdfTemplatesPage', () => {
         expect(screen.getByText(/Mapped Fields \(1\)/)).toBeInTheDocument();
         expect(screen.getByText('Detail Table')).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('default template', () => {
+    it('should show Set as Default button for non-default templates', async () => {
+      renderPage();
+
+      await simulateTemplates([
+        makeTemplateDoc('tmpl1', { name: 'OCPS Form', fileName: 'ocps.pdf', fields: [], pageCount: 1 }),
+      ]);
+
+      expect(screen.getByRole('button', { name: /Set as Default/i })).toBeInTheDocument();
+    });
+
+    it('should show Default badge for the default template', async () => {
+      const { setDoc } = await import('firebase/firestore');
+      const user = userEvent.setup();
+      renderPage();
+
+      await simulateTemplates([
+        makeTemplateDoc('tmpl1', { name: 'OCPS Form', fileName: 'ocps.pdf', fields: [], pageCount: 1 }),
+      ]);
+
+      await user.click(screen.getByRole('button', { name: /Set as Default/i }));
+
+      expect(setDoc).toHaveBeenCalled();
+    });
+
+    it('should not show Set as Default button when template is already default', async () => {
+      const { onSnapshot } = await import('firebase/firestore');
+      renderPage();
+
+      await simulateTemplates([
+        makeTemplateDoc('tmpl1', { name: 'OCPS Form', fileName: 'ocps.pdf', fields: [], pageCount: 1 }),
+      ]);
+
+      // Simulate the defaults snapshot returning tmpl1 as default
+      const { vi: viTest } = await import('vitest');
+      const calls = onSnapshot.mock.calls;
+      const docCallback = calls.find(([ref]) => ref?._isDoc)?.[1];
+      if (docCallback) {
+        await act(async () => {
+          docCallback({ exists: () => true, data: () => ({ defaultTemplateId: 'tmpl1' }) });
+        });
+        expect(screen.queryByRole('button', { name: /Set as Default/i })).not.toBeInTheDocument();
+        expect(screen.getByText('Default')).toBeInTheDocument();
+      }
     });
   });
 

--- a/frontend/src/pages/StudentDetailPage.jsx
+++ b/frontend/src/pages/StudentDetailPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { printInNewWindow, createPrintDocument } from '../utils/printUtils';
 import { formatTime, formatHours } from '../utils/hourCalculations';
+import { generateFilledPdf, openPdfForPrinting } from '../utils/pdfTemplateUtils';
 
 import { db, functions, storage } from '../utils/firebase';
 import { doc, getDoc, collection, query, where, onSnapshot, orderBy, Timestamp, updateDoc } from 'firebase/firestore';
@@ -9,7 +10,6 @@ import { ref, getDownloadURL } from 'firebase/storage';
 import { httpsCallable } from 'firebase/functions';
 
 import { useEvent } from '../contexts/EventContext';
-import { generateFilledPdf, downloadPdf } from '../utils/pdfTemplateUtils';
 import { buildEditChangeDescription } from '../utils/changeDescriptions';
 import Header from '../components/common/Header';
 import Spinner from '../components/common/Spinner';
@@ -32,6 +32,7 @@ export default function StudentDetailPage() {
     // PDF template state
     const [pdfTemplates, setPdfTemplates] = useState([]);
     const [selectedTemplateId, setSelectedTemplateId] = useState(null);
+    const [defaultTemplateId, setDefaultTemplateId] = useState(null);
     const [generatingPdf, setGeneratingPdf] = useState(false);
 
     // Edit hours modal state
@@ -92,12 +93,15 @@ export default function StudentDetailPage() {
         if (studentId) fetchStudent();
     }, [studentId]);
 
-    // Fetch PDF templates
+    // Fetch PDF templates and default template setting
     useEffect(() => {
-        const unsubscribe = onSnapshot(collection(db, 'pdfTemplates'), (snapshot) => {
+        const unsubTemplates = onSnapshot(collection(db, 'pdfTemplates'), (snapshot) => {
             setPdfTemplates(snapshot.docs.map(d => ({ id: d.id, ...d.data() })));
         });
-        return () => unsubscribe();
+        const unsubDefaults = onSnapshot(doc(db, 'settings', 'pdfDefaults'), (snap) => {
+            setDefaultTemplateId(snap.exists() ? snap.data().defaultTemplateId : null);
+        });
+        return () => { unsubTemplates(); unsubDefaults(); };
     }, []);
 
     useEffect(() => {
@@ -283,65 +287,54 @@ export default function StudentDetailPage() {
         }
     };
 
-    // Generate and download filled PDF from template
-    const handleGeneratePdf = async () => {
+    // Print service log: student template → default template → HTML fallback
+    const handlePrintForm = async () => {
         if (hasUncheckedOutEntries) {
-            alert('Cannot generate PDF: This student has time entries that are not checked out. Please ensure all entries have checkout times before printing.');
-            return;
-        }
-        const template = pdfTemplates.find(t => t.id === selectedTemplateId);
-        if (!template) {
-            alert('Please select a PDF template first.');
-            return;
-        }
-        if (!template.fields || template.fields.length === 0) {
-            alert('This template has no mapped fields. Please map fields in Settings > PDF Templates first.');
-            return;
-        }
-
-        setGeneratingPdf(true);
-        try {
-            // Fetch the template PDF from storage
-            const storageRef = ref(storage, template.storagePath);
-            const url = await getDownloadURL(storageRef);
-            const response = await fetch(url);
-            const templateBytes = await response.arrayBuffer();
-
-            // Generate the filled PDF
-            const pdfBytes = await generateFilledPdf(templateBytes, template.fields, {
-                student,
-                totalHours: grandTotal,
-                eventName: currentEvent?.name || '',
-                activityLog,
-                event: currentEvent,
-                timeEntries: entries.filter(e => !e.isVoided),
-            });
-
-            // Download it
-            const filename = `${student.firstName}_${student.lastName}_${template.name.replace(/\s+/g, '_')}.pdf`;
-            downloadPdf(pdfBytes, filename);
-        } catch (err) {
-            console.error('PDF generation failed:', err);
-            alert('Failed to generate PDF: ' + err.message);
-        } finally {
-            setGeneratingPdf(false);
-        }
-    };
-
-    const handlePrint = (mode) => {
-        if (mode === 'form' && hasUncheckedOutEntries) {
             alert('Cannot print Service Log: This student has time entries that are not checked out. Please ensure all entries have checkout times before printing.');
             return;
         }
 
-        // Keep printMode state only for UX; actual printing happens in a new window
-        setPrintMode(mode);
+        const effectiveTemplateId = selectedTemplateId || defaultTemplateId;
+        const template = pdfTemplates.find(t => t.id === effectiveTemplateId);
 
-        if (mode === 'badge') {
-            printElementById('printable-badge', 'Badge');
+        if (template) {
+            if (!template.fields || template.fields.length === 0) {
+                alert('The selected template has no mapped fields. Please map fields in Settings > PDF Templates first.');
+                return;
+            }
+            setGeneratingPdf(true);
+            try {
+                const storageRef = ref(storage, template.storagePath);
+                const url = await getDownloadURL(storageRef);
+                const response = await fetch(url);
+                const templateBytes = await response.arrayBuffer();
+
+                const pdfBytes = await generateFilledPdf(templateBytes, template.fields, {
+                    student,
+                    totalHours: grandTotal,
+                    eventName: currentEvent?.name || '',
+                    activityLog,
+                    event: currentEvent,
+                    timeEntries: entries.filter(e => !e.isVoided),
+                });
+
+                openPdfForPrinting(pdfBytes, `${student.firstName}_${student.lastName}_service_log.pdf`);
+            } catch (err) {
+                console.error('PDF generation failed:', err);
+                alert('Failed to generate PDF: ' + err.message);
+            } finally {
+                setGeneratingPdf(false);
+            }
         } else {
+            // HTML fallback: no template configured
+            setPrintMode('form');
             printElementById('ocps-form', 'Service Log');
         }
+    };
+
+    const handlePrint = (mode) => {
+        setPrintMode(mode);
+        printElementById('printable-badge', 'Badge');
     };
 
     // Format date for datetime-local input using LOCAL time (not UTC)
@@ -590,24 +583,9 @@ export default function StudentDetailPage() {
           @media print {
             .no-print { display: none !important; }
             #printable-badge { display: ${printMode === 'badge' ? 'flex' : 'none'} !important; }
-            #ocps-form { display: ${printMode === 'form' ? 'block' : 'none'} !important; }
 
             body { background: white; margin: 0; padding: 0; }
-            .ocps-form-container {
-              font-family: Arial, sans-serif;
-              padding: 0.3in;
-              color: black;
-              line-height: 1.1;
-              font-size: 9pt;
-            }
-            table { border-collapse: collapse; width: 100%; margin-bottom: 4px; }
-            th, td { border: 1px solid black; padding: 4px 8px; vertical-align: middle; }
-            .field-box { border-bottom: 1px solid black; display: inline-block; min-width: 120px; padding: 0 5px; font-weight: bold; }
-            .reflection-box { border: 1px solid black; height: 210px; width: 100%; margin-top: 4px; display: flex; flex-direction: column; }
-            .reflection-line { border-bottom: 1px solid #eee; flex: 1; }
-            .ocps-logo { width: 45px; height: 45px; border: 1px solid black; display: flex; align-items: center; justify-content: center; font-weight: bold; font-size: 8pt; text-align: center; }
 
-            /* Badge printing styles */
             #printable-badge {
               justify-content: center;
               align-items: center;
@@ -626,29 +604,12 @@ export default function StudentDetailPage() {
               width: 3.5in;
               height: 2.5in;
             }
-            .badge-name {
-              font-size: 16pt;
-              font-weight: bold;
-              margin-bottom: 4px;
-              color: #000;
-            }
-            .badge-id {
-              font-size: 9pt;
-              color: #666;
-              margin-bottom: 8px;
-            }
-            .badge-qr {
-              margin: 0 auto;
-            }
-            .badge-event {
-              font-size: 8pt;
-              color: #333;
-              margin-top: 8px;
-              text-transform: uppercase;
-              font-weight: bold;
-            }
+            .badge-name { font-size: 16pt; font-weight: bold; margin-bottom: 4px; color: #000; }
+            .badge-id { font-size: 9pt; color: #666; margin-bottom: 8px; }
+            .badge-qr { margin: 0 auto; }
+            .badge-event { font-size: 8pt; color: #333; margin-top: 8px; text-transform: uppercase; font-weight: bold; }
           }
-          #printable-badge, #ocps-form { display: none; }
+          #printable-badge { display: none; }
         `}
                 </style>
 
@@ -659,31 +620,33 @@ export default function StudentDetailPage() {
                         <p className="text-gray-500 font-medium text-sm sm:text-base">{student?.schoolName} • Grade {student?.gradeLevel}</p>
                     </div>
                     <div className="flex gap-3 flex-wrap sm:flex-nowrap items-center">
-                        <Button onClick={() => handlePrint('form')} variant="secondary" className="flex-1 sm:flex-none min-h-[44px]">Print Service Log</Button>
+                        <Button
+                            onClick={handlePrintForm}
+                            variant="secondary"
+                            disabled={generatingPdf}
+                            loading={generatingPdf}
+                            className="flex-1 sm:flex-none min-h-[44px]"
+                        >
+                            Print Service Log
+                        </Button>
                         <Button onClick={() => handlePrint('badge')} variant="primary" className="flex-1 sm:flex-none min-h-[44px]">Print Badge</Button>
                         {pdfTemplates.length > 0 && (
-                            <>
-                                <select
-                                    value={selectedTemplateId || ''}
-                                    onChange={(e) => handleTemplateChange(e.target.value)}
-                                    className="input-field text-sm min-h-[44px]"
-                                    aria-label="PDF Template"
-                                >
-                                    <option value="">Select Template...</option>
-                                    {pdfTemplates.map(t => (
-                                        <option key={t.id} value={t.id}>{t.name}</option>
-                                    ))}
-                                </select>
-                                <Button
-                                    onClick={handleGeneratePdf}
-                                    variant="success"
-                                    disabled={!selectedTemplateId || generatingPdf}
-                                    loading={generatingPdf}
-                                    className="flex-1 sm:flex-none min-h-[44px]"
-                                >
-                                    Print Hours Form
-                                </Button>
-                            </>
+                            <select
+                                value={selectedTemplateId || ''}
+                                onChange={(e) => handleTemplateChange(e.target.value)}
+                                className="input-field text-sm min-h-[44px]"
+                                aria-label="PDF Template Override"
+                                title={defaultTemplateId ? 'Override the default template for this student' : 'Assign a template to this student'}
+                            >
+                                <option value="">
+                                    {defaultTemplateId
+                                        ? `Default: ${pdfTemplates.find(t => t.id === defaultTemplateId)?.name || 'Default'}`
+                                        : 'Select Template Override...'}
+                                </option>
+                                {pdfTemplates.map(t => (
+                                    <option key={t.id} value={t.id}>{t.name}</option>
+                                ))}
+                            </select>
                         )}
                     </div>
                 </div>
@@ -786,13 +749,12 @@ export default function StudentDetailPage() {
                     </div>
                 </div>
 
-                {/* OCPS FORM (Matches Rev 8/2023) */}
-                <div id="ocps-form" className="ocps-form-container">
+                {/* HTML fallback form — only used when no PDF template is configured */}
+                <div id="ocps-form" style={{ display: 'none' }} className="ocps-form-container">
                     <div className="flex items-center justify-between mb-4 border-b-2 border-black pb-2">
                         <div className="ocps-logo">OCPS</div>
                         <h1 className="text-xl font-bold text-center flex-1">Community/Work Service Log and Reflection</h1>
                     </div>
-
                     <table className="mb-2">
                         <tbody>
                             <tr>
@@ -805,12 +767,10 @@ export default function StudentDetailPage() {
                             </tr>
                         </tbody>
                     </table>
-
                     <p className="text-[8pt] mb-1">Social/Civic Issue/Professional Area Addressing with Service Activity Log (Optional):</p>
                     <div className="border-b border-black w-full mb-2 h-5"></div>
                     <p className="font-bold text-[9pt] mb-1">Description of Volunteer/Paid Work Activity:</p>
                     <div className="border-b border-black w-full mb-4 h-5"></div>
-
                     <table className="mb-2 text-center">
                         <thead>
                             <tr className="bg-gray-100 text-[8pt]">
@@ -831,7 +791,6 @@ export default function StudentDetailPage() {
                                     <td className="font-bold">{act.totalHours}</td>
                                 </tr>
                             ))}
-                            {/* Blank placeholder rows to maintain form length */}
                             {[...Array(Math.max(0, 10 - activityLog.length))].map((_, i) => (
                                 <tr key={`blank-${i}`} className="h-9">
                                     <td></td><td></td><td></td><td></td><td></td>
@@ -843,7 +802,6 @@ export default function StudentDetailPage() {
                             </tr>
                         </tbody>
                     </table>
-
                     <div className="mt-2">
                         <p className="font-bold text-[8pt] mb-0">Reflection on Service Activity/Work (attach additional pages if necessary):</p>
                         <p className="text-[7pt] italic mb-1">Attach a copy of your pay stub for work hours if applicable. Complete the reflection below...</p>
@@ -851,9 +809,7 @@ export default function StudentDetailPage() {
                             {[...Array(8)].map((_, i) => <div key={i} className="reflection-line"></div>)}
                         </div>
                     </div>
-
                     <p className="text-[7.5pt] mt-4 font-bold leading-tight">By signing below, I certify that all information on this document is true and correct. I understand that if I am found to have given false testimony about these hours that the hours will be revoked and endanger my eligibility for the Bright Futures Scholarship.</p>
-
                     <div className="mt-6 flex justify-between">
                         <div className="text-[8.5pt]">Student Signature: _______________________ Date: ________</div>
                         <div className="text-[8.5pt]">Parent Signature: ________________________ Date: ________</div>

--- a/frontend/src/pages/StudentDetailPage.jsx
+++ b/frontend/src/pages/StudentDetailPage.jsx
@@ -11,7 +11,6 @@ import { httpsCallable } from 'firebase/functions';
 
 import { useEvent } from '../contexts/EventContext';
 import { buildEditChangeDescription } from '../utils/changeDescriptions';
-import Header from '../components/common/Header';
 import Spinner from '../components/common/Spinner';
 import Button from '../components/common/Button';
 import Modal from '../components/common/Modal';
@@ -569,14 +568,12 @@ export default function StudentDetailPage() {
 
     if (loading) return (
         <div className="min-h-screen bg-gray-50">
-            <Header />
             <div className="p-20 text-center"><Spinner size="lg" /></div>
         </div>
     );
 
     return (
         <div className="min-h-screen bg-gray-50">
-            <Header />
             <div className="max-w-7xl mx-auto p-6">
                 <style>
                     {`

--- a/frontend/src/pages/StudentDetailPage.manualEntry.test.jsx
+++ b/frontend/src/pages/StudentDetailPage.manualEntry.test.jsx
@@ -7,13 +7,14 @@ import { act } from 'react-dom/test-utils';
 
 // Mock Firebase
 vi.mock('../utils/firebase', () => ({
-    db: {}
+    db: {},
+    storage: {},
 }));
 
 // Mock Firestore functions
 vi.mock('firebase/firestore', () => ({
-    collection: vi.fn(),
-    doc: vi.fn(() => ({ id: 'entry123' })),
+    collection: vi.fn((db, path) => ({ _collPath: path })),
+    doc: vi.fn((db, ...args) => ({ _isDoc: true, id: args[args.length - 1] })),
     getDoc: vi.fn(() => Promise.resolve({
         exists: () => true,
         id: 'student123',
@@ -25,18 +26,35 @@ vi.mock('firebase/firestore', () => ({
             gradYear: '2028'
         })
     })),
-    onSnapshot: vi.fn((query, callback) => {
-        callback({ docs: [] }); // Start with empty entries
+    onSnapshot: vi.fn((queryOrRef, callback) => {
+        if (queryOrRef?._isDoc) {
+            callback({ exists: () => false, data: () => null });
+        } else {
+            callback({ docs: [] }); // Start with empty entries
+        }
         return vi.fn();
     }),
-    query: vi.fn(),
-    where: vi.fn(),
-    orderBy: vi.fn(),
+    query: vi.fn((ref) => ref),
+    where: vi.fn(() => ({})),
+    orderBy: vi.fn(() => ({})),
     Timestamp: {
         fromDate: (date) => ({ toDate: () => date, seconds: Math.floor(date.getTime() / 1000) })
     },
     addDoc: vi.fn(),
     updateDoc: vi.fn()
+}));
+
+// Mock Firebase Storage
+vi.mock('firebase/storage', () => ({
+    ref: vi.fn(),
+    getDownloadURL: vi.fn(() => Promise.resolve('https://storage.example.com/template.pdf')),
+}));
+
+// Mock pdfTemplateUtils
+vi.mock('../utils/pdfTemplateUtils', () => ({
+    generateFilledPdf: vi.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
+    openPdfForPrinting: vi.fn(),
+    downloadPdf: vi.fn(),
 }));
 
 // Mock AuthContext

--- a/frontend/src/pages/StudentDetailPage.test.jsx
+++ b/frontend/src/pages/StudentDetailPage.test.jsx
@@ -6,13 +6,14 @@ import StudentDetailPage from './StudentDetailPage';
 
 // Mock Firebase
 vi.mock('../utils/firebase', () => ({
-  db: {}
+  db: {},
+  storage: {},
 }));
 
 // Mock Firestore functions
 vi.mock('firebase/firestore', () => ({
-  collection: vi.fn(),
-  doc: vi.fn(() => ({ id: 'entry123' })),
+  collection: vi.fn((db, path) => ({ _collPath: path })),
+  doc: vi.fn((db, ...args) => ({ _isDoc: true, id: args[args.length - 1] })),
   getDoc: vi.fn(() => Promise.resolve({
     exists: () => true,
     id: 'student123',
@@ -24,45 +25,65 @@ vi.mock('firebase/firestore', () => ({
       gradYear: '2028'
     })
   })),
-  onSnapshot: vi.fn((query, callback) => {
-    // Simulate time entries data
-    callback({
-      docs: [
-        {
-          id: 'entry1',
-          data: () => ({
-            studentId: 'student123',
-            activityId: 'activity1',
-            checkInTime: { toDate: () => new Date('2026-01-31T08:00:00'), seconds: 1738314000 },
-            checkOutTime: { toDate: () => new Date('2026-01-31T12:00:00'), seconds: 1738328400 },
-            hoursWorked: 4,
-            flags: [],
-            changeLog: []
-          })
-        },
-        {
-          id: 'entry2',
-          data: () => ({
-            studentId: 'student123',
-            activityId: 'activity1',
-            checkInTime: { toDate: () => new Date('2026-01-30T08:30:00'), seconds: 1738229400 },
-            checkOutTime: null,
-            hoursWorked: null,
-            flags: ['early_arrival'],
-            changeLog: []
-          })
-        }
-      ]
-    });
+  onSnapshot: vi.fn((queryOrRef, callback) => {
+    if (queryOrRef?._isDoc) {
+      // Document snapshot (settings/pdfDefaults)
+      callback({ exists: () => false, data: () => null });
+    } else if (queryOrRef?._collPath === 'pdfTemplates') {
+      callback({ docs: [] });
+    } else {
+      // timeEntries collection
+      callback({
+        docs: [
+          {
+            id: 'entry1',
+            data: () => ({
+              studentId: 'student123',
+              activityId: 'activity1',
+              checkInTime: { toDate: () => new Date('2026-01-31T08:00:00'), seconds: 1738314000 },
+              checkOutTime: { toDate: () => new Date('2026-01-31T12:00:00'), seconds: 1738328400 },
+              hoursWorked: 4,
+              flags: [],
+              changeLog: []
+            })
+          },
+          {
+            id: 'entry2',
+            data: () => ({
+              studentId: 'student123',
+              activityId: 'activity1',
+              checkInTime: { toDate: () => new Date('2026-01-30T08:30:00'), seconds: 1738229400 },
+              checkOutTime: null,
+              hoursWorked: null,
+              flags: ['early_arrival'],
+              changeLog: []
+            })
+          }
+        ]
+      });
+    }
     return vi.fn(); // unsubscribe function
   }),
-  query: vi.fn(),
-  where: vi.fn(),
-  orderBy: vi.fn(),
+  query: vi.fn((ref) => ref),
+  where: vi.fn(() => ({})),
+  orderBy: vi.fn(() => ({})),
   Timestamp: {
     fromDate: (date) => ({ toDate: () => date, seconds: Math.floor(date.getTime() / 1000) })
   },
   updateDoc: vi.fn()
+}));
+
+// Mock Firebase Storage
+vi.mock('firebase/storage', () => ({
+  ref: vi.fn(),
+  getDownloadURL: vi.fn(() => Promise.resolve('https://storage.example.com/template.pdf')),
+}));
+
+// Mock pdfTemplateUtils
+vi.mock('../utils/pdfTemplateUtils', () => ({
+  generateFilledPdf: vi.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
+  openPdfForPrinting: vi.fn(),
+  downloadPdf: vi.fn(),
 }));
 
 // Mock AuthContext
@@ -196,7 +217,7 @@ describe('StudentDetailPage', () => {
         // Desktop view has table headers, mobile view has "Service Log" heading
         // Check for either desktop table headers or mobile service log header
         const hasDesktopTable = screen.queryByText('Date') !== null;
-        const hasMobileServiceLog = screen.queryByText('Service Log') !== null;
+        const hasMobileServiceLog = screen.queryAllByText('Service Log').length > 0;
         expect(hasDesktopTable || hasMobileServiceLog).toBe(true);
 
         // Check for entry content that appears in both views

--- a/frontend/src/pages/StudentsPage.jsx
+++ b/frontend/src/pages/StudentsPage.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { printInNewWindow, createPrintDocument } from '../utils/printUtils';
-import { db } from '../utils/firebase';
-import { collection, onSnapshot, addDoc, serverTimestamp, query, where } from 'firebase/firestore';
+import { db, storage } from '../utils/firebase';
+import { collection, onSnapshot, addDoc, serverTimestamp, query, where, doc } from 'firebase/firestore';
+import { ref, getDownloadURL } from 'firebase/storage';
+import { generateFilledPdf, mergePdfs, openPdfForPrinting } from '../utils/pdfTemplateUtils';
 import { useEvent } from '../contexts/EventContext';
 import Header from '../components/common/Header';
 import Button from '../components/common/Button';
@@ -19,9 +21,11 @@ export default function StudentsPage() {
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [printMode, setPrintMode] = useState(false);
   const [badgePrintMode, setBadgePrintMode] = useState(false);
   const [selectedStudents, setSelectedStudents] = useState(new Set());
+  const [pdfTemplates, setPdfTemplates] = useState([]);
+  const [defaultTemplateId, setDefaultTemplateId] = useState(null);
+  const [printingReports, setPrintingReports] = useState(false);
 
   const [formData, setFormData] = useState({
     firstName: '',
@@ -31,27 +35,24 @@ export default function StudentsPage() {
     gradYear: ''
   });
 
-  // Watch for printMode changes and reset after print dialog closes
-  useEffect(() => {
-    if (!printMode) return;
-    
-    const timer = setTimeout(() => {
-      setPrintMode(false);
-    }, 3000);
-    
-    return () => clearTimeout(timer);
-  }, [printMode]);
-
   // Watch for badgePrintMode changes and reset after print dialog closes
   useEffect(() => {
     if (!badgePrintMode) return;
-    
-    const timer = setTimeout(() => {
-      setBadgePrintMode(false);
-    }, 3000);
-    
+    const timer = setTimeout(() => setBadgePrintMode(false), 3000);
     return () => clearTimeout(timer);
-  }, [badgePrintMode]);  useEffect(() => {
+  }, [badgePrintMode]);
+
+  useEffect(() => {
+    const unsubTemplates = onSnapshot(collection(db, 'pdfTemplates'), (snapshot) => {
+      setPdfTemplates(snapshot.docs.map(d => ({ id: d.id, ...d.data() })));
+    });
+    const unsubDefaults = onSnapshot(doc(db, 'settings', 'pdfDefaults'), (snap) => {
+      setDefaultTemplateId(snap.exists() ? snap.data().defaultTemplateId : null);
+    });
+    return () => { unsubTemplates(); unsubDefaults(); };
+  }, []);
+
+  useEffect(() => {
     // 1. Listen for all student records
     const unsubStudents = onSnapshot(collection(db, 'students'), (snapshot) => {
       setStudents(snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })));
@@ -237,8 +238,136 @@ export default function StudentsPage() {
     });
   };
 
-  const handlePrintReports = () => {
-    printElementById('print-all-forms', 'Service Logs', setPrintMode);
+  // Returns the effective PDF template for a student (own → default → null)
+  const getEffectiveTemplate = (student) => {
+    const id = student.pdfTemplateId || defaultTemplateId;
+    return id ? pdfTemplates.find(t => t.id === id) || null : null;
+  };
+
+  // Builds the HTML string for one student's OCPS form (used as HTML fallback)
+  const buildStudentFormHtml = (student, activityLog, grandTotal) => {
+    const orgName = currentEvent?.organizationName || '';
+    const contactName = currentEvent?.contactName || '---';
+    const activityRows = activityLog.map(act => `
+      <tr class="h9">
+        <td>${orgName} ${act.name || ''}</td>
+        <td style="text-align:center">${act.dateDisplay}</td>
+        <td>${contactName}</td>
+        <td></td>
+        <td style="font-weight:bold">${act.totalHours}</td>
+      </tr>`).join('');
+    const blankRows = Array.from({ length: Math.max(0, 10 - activityLog.length) })
+      .map(() => '<tr style="height:36px"><td></td><td></td><td></td><td></td><td></td></tr>').join('');
+
+    return `<div class="ocps-form-container">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;border-bottom:2px solid black;padding-bottom:4px">
+        <div class="ocps-logo">OCPS</div>
+        <h1 style="font-size:13pt;font-weight:bold;text-align:center;flex:1">Community/Work Service Log and Reflection</h1>
+      </div>
+      <table style="margin-bottom:4px"><tbody>
+        <tr>
+          <td style="width:33%;border:none">Student ID #: <span class="field-box" style="min-width:100px"></span></td>
+          <td style="border:none">Student Name: <span class="field-box" style="min-width:220px">${student.firstName} ${student.lastName}</span></td>
+        </tr>
+        <tr>
+          <td style="border:none">School Name: <span class="field-box" style="min-width:200px">${student.schoolName || ''}</span></td>
+          <td style="border:none;text-align:right">Graduation Year: <span class="field-box" style="min-width:80px">${student.gradYear || '____'}</span></td>
+        </tr>
+      </tbody></table>
+      <p style="font-size:7.5pt;margin:2px 0">Social/Civic Issue/Professional Area Addressing with Service Activity Log (Optional):</p>
+      <div style="border-bottom:1px solid black;width:100%;margin-bottom:4px;height:16px"></div>
+      <p style="font-weight:bold;font-size:8pt;margin:2px 0">Description of Volunteer/Paid Work Activity:</p>
+      <div style="border-bottom:1px solid black;width:100%;margin-bottom:8px;height:16px"></div>
+      <table style="margin-bottom:8px;text-align:center"><thead>
+        <tr style="background:#f3f4f6;font-size:8pt">
+          <th style="width:20%">Service Organization/Business</th>
+          <th style="width:30%">Date(s) of Service Activity/Work</th>
+          <th style="width:15%">Contact Name</th>
+          <th style="width:20%">Signature of Contact</th>
+          <th style="width:15%">Hours Completed</th>
+        </tr>
+      </thead><tbody>
+        ${activityRows}${blankRows}
+        <tr>
+          <td colspan="4" style="text-align:right;font-weight:bold;text-transform:uppercase">Total:</td>
+          <td style="font-weight:bold;background:#f9fafb">${grandTotal.toFixed(2)}</td>
+        </tr>
+      </tbody></table>
+      <div style="margin-top:4px">
+        <p style="font-weight:bold;font-size:7.5pt;margin:0">Reflection on Service Activity/Work (attach additional pages if necessary):</p>
+        <p style="font-size:6.5pt;font-style:italic;margin:2px 0">Attach a copy of your pay stub for work hours if applicable. Complete the reflection below...</p>
+        <div class="reflection-box">${Array.from({ length: 7 }).map(() => '<div class="reflection-line"></div>').join('')}</div>
+      </div>
+      <p style="font-size:7pt;margin-top:8px;font-weight:bold;line-height:1.3">By signing below, I certify that all information on this document is true and correct. I understand that if I am found to have given false testimony about these hours that the hours will be revoked and endanger my eligibility for the Bright Futures Scholarship.</p>
+      <div style="margin-top:12px;display:flex;justify-content:space-between">
+        <div style="font-size:8pt">Student Signature: _______________________ Date: ________</div>
+        <div style="font-size:8pt">Parent Signature: ________________________ Date: ________</div>
+      </div>
+      <p style="font-size:5.5pt;margin-top:4px;color:#9ca3af">Revised 8/2023</p>
+    </div>`;
+  };
+
+  const handlePrintReports = async () => {
+    const studentsToPrint = getStudentsToPrint();
+    const pdfGroup = [];
+    const htmlGroup = [];
+
+    for (const student of studentsToPrint) {
+      const template = getEffectiveTemplate(student);
+      if (template) {
+        pdfGroup.push({ student, template });
+      } else {
+        htmlGroup.push(student);
+      }
+    }
+
+    // PDF path: generate, merge, open print dialog
+    if (pdfGroup.length > 0) {
+      setPrintingReports(true);
+      try {
+        const allPdfBytes = [];
+        for (const { student, template } of pdfGroup) {
+          const storageRef = ref(storage, template.storagePath);
+          const url = await getDownloadURL(storageRef);
+          const response = await fetch(url);
+          const templateBytes = await response.arrayBuffer();
+
+          const activityLog = getStudentActivityLog(student.id);
+          const totalCalc = activityLog.reduce((sum, a) => sum + parseFloat(a.totalHours), 0);
+          const grandTotal = totalCalc + parseFloat(student.overrideHours || 0);
+
+          const pdfBytes = await generateFilledPdf(templateBytes, template.fields, {
+            student,
+            totalHours: grandTotal,
+            eventName: currentEvent?.name || '',
+            activityLog,
+            event: currentEvent,
+            timeEntries: allEntries.filter(e => e.studentId === student.id && !e.isVoided),
+          });
+          allPdfBytes.push(pdfBytes);
+        }
+        const mergedBytes = await mergePdfs(allPdfBytes);
+        openPdfForPrinting(mergedBytes, 'service-logs.pdf');
+      } catch (err) {
+        console.error('Bulk PDF generation failed:', err);
+        alert('Failed to generate PDFs: ' + err.message);
+      } finally {
+        setPrintingReports(false);
+      }
+    }
+
+    // HTML fallback path: students with no template
+    if (htmlGroup.length > 0) {
+      const formsHtml = htmlGroup.map(student => {
+        const activityLog = getStudentActivityLog(student.id);
+        const totalCalc = activityLog.reduce((sum, a) => sum + parseFloat(a.totalHours), 0);
+        const grandTotal = totalCalc + parseFloat(student.overrideHours || 0);
+        return buildStudentFormHtml(student, activityLog, grandTotal);
+      }).join('');
+
+      const html = createPrintDocument({ title: 'Service Logs', styles: PRINT_STYLES, body: formsHtml });
+      printInNewWindow(html);
+    }
   };
 
   const handlePrintBadges = () => {
@@ -264,31 +393,9 @@ export default function StudentsPage() {
         {`
           @media print {
             .no-print { display: none !important; }
-            #print-all-forms { display: ${printMode ? 'block' : 'none'} !important; }
             #print-all-badges { display: ${badgePrintMode ? 'block' : 'none'} !important; }
 
             body { background: white; margin: 0; padding: 0; }
-            .ocps-form-container {
-              font-family: Arial, sans-serif;
-              padding: 0.25in;
-              color: black;
-              line-height: 1.05;
-              font-size: 8.5pt;
-              page-break-after: always;
-              height: 100vh;
-              box-sizing: border-box;
-            }
-            .ocps-form-container:last-child {
-              page-break-after: auto;
-            }
-            table { border-collapse: collapse; width: 100%; margin-bottom: 2px; }
-            th, td { border: 1px solid black; padding: 2px 6px; vertical-align: middle; }
-            .field-box { border-bottom: 1px solid black; display: inline-block; min-width: 120px; padding: 0 5px; font-weight: bold; }
-            .reflection-box { border: 1px solid black; height: 165px; width: 100%; margin-top: 2px; display: flex; flex-direction: column; }
-            .reflection-line { border-bottom: 1px solid #eee; flex: 1; }
-            .ocps-logo { width: 40px; height: 40px; border: 1px solid black; display: flex; align-items: center; justify-content: center; font-weight: bold; font-size: 7pt; text-align: center; }
-
-            /* Badge printing styles */
             .badge-page {
               page-break-after: always;
               height: 100vh;
@@ -300,9 +407,7 @@ export default function StudentsPage() {
               padding: 0.25in;
               box-sizing: border-box;
             }
-            .badge-page:last-child {
-              page-break-after: auto;
-            }
+            .badge-page:last-child { page-break-after: auto; }
             .student-badge {
               border: 2px solid #000;
               padding: 0.15in;
@@ -315,22 +420,10 @@ export default function StudentsPage() {
               text-align: center;
               margin: 2px;
             }
-            .badge-name {
-              font-size: 14pt;
-              font-weight: bold;
-              margin-bottom: 4px;
-              color: #000;
-            }
-            .badge-id {
-              font-size: 9pt;
-              color: #666;
-              margin-bottom: 8px;
-            }
-            .badge-qr {
-              margin: 0 auto;
-            }
+            .badge-name { font-size: 14pt; font-weight: bold; margin-bottom: 4px; color: #000; }
+            .badge-id { font-size: 9pt; color: #666; margin-bottom: 8px; }
+            .badge-qr { margin: 0 auto; }
           }
-          #print-all-forms { display: none; }
           #print-all-badges { display: none; }
         `}
       </style>
@@ -351,8 +444,8 @@ export default function StudentsPage() {
           <Button onClick={handlePrintBadges} variant="secondary">
             {selectedStudents.size > 0 ? `Print Badges (${selectedStudents.size})` : 'Print Badges'}
           </Button>
-          <Button onClick={handlePrintReports} variant="secondary">
-            {selectedStudents.size > 0 ? `Print Reports (${selectedStudents.size})` : 'Print Reports'}
+          <Button onClick={handlePrintReports} variant="secondary" disabled={printingReports} loading={printingReports}>
+            {printingReports ? 'Generating...' : selectedStudents.size > 0 ? `Print Reports (${selectedStudents.size})` : 'Print Reports'}
           </Button>
           <Button onClick={() => setIsModalOpen(true)} variant="primary">+ Add Student</Button>
         </div>
@@ -521,91 +614,6 @@ export default function StudentsPage() {
           </div>
         </div>
       )}
-
-      {/* PRINT ALL FORMS */}
-      <div id="print-all-forms">
-        {getStudentsToPrint().map((student) => {
-          const activityLog = getStudentActivityLog(student.id);
-          const totalCalculatedHours = activityLog.reduce((sum, act) => sum + parseFloat(act.totalHours), 0);
-          const overrideHours = parseFloat(student?.overrideHours || 0);
-          const grandTotal = totalCalculatedHours + overrideHours;
-
-          return (
-            <div key={student.id} className="ocps-form-container">
-              <div className="flex items-center justify-between mb-2 border-b-2 border-black pb-1">
-                <div className="ocps-logo">OCPS</div>
-                <h1 className="text-lg font-bold text-center flex-1">Community/Work Service Log and Reflection</h1>
-              </div>
-
-              <table className="mb-1">
-                <tbody>
-                  <tr>
-                    <td className="w-1/3 border-none">Student ID #: <span className="field-box" style={{ minWidth: '100px' }}></span></td>
-                    <td className="border-none">Student Name: <span className="field-box" style={{ minWidth: '220px' }}>{student.firstName} {student.lastName}</span></td>
-                  </tr>
-                  <tr>
-                    <td className="border-none">School Name: <span className="field-box" style={{ minWidth: '200px' }}>{student.schoolName}</span></td>
-                    <td className="border-none text-right">Graduation Year: <span className="field-box" style={{ minWidth: '80px' }}>{student.gradYear || '____'}</span></td>
-                  </tr>
-                </tbody>
-              </table>
-
-              <p className="text-[7.5pt] mb-0.5">Social/Civic Issue/Professional Area Addressing with Service Activity Log (Optional):</p>
-              <div className="border-b border-black w-full mb-1 h-4"></div>
-              <p className="font-bold text-[8pt] mb-0.5">Description of Volunteer/Paid Work Activity:</p>
-              <div className="border-b border-black w-full mb-2 h-4"></div>
-
-              <table className="mb-2 text-center">
-                <thead>
-                  <tr className="bg-gray-100 text-[8pt]">
-                    <th className="w-[20%]">Service Organization/Business</th>
-                    <th className="w-[30%]">Date(s) of Service Activity/Work</th>
-                    <th className="w-[15%]">Contact Name</th>
-                    <th className="w-[20%]">Signature of Contact</th>
-                    <th className="w-[15%]">Hours Completed</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {activityLog.map((act, i) => (
-                    <tr key={i} className="h-9">
-                      <td>{currentEvent?.organizationName} {act?.name}</td>
-                      <td className="text-center">{act.dateDisplay}</td>
-                      <td>{currentEvent?.contactName || '---'}</td>
-                      <td></td>
-                      <td className="font-bold">{act.totalHours}</td>
-                    </tr>
-                  ))}
-                  {[...Array(Math.max(0, 10 - activityLog.length))].map((_, i) => (
-                    <tr key={`blank-${i}`} className="h-9">
-                      <td></td><td></td><td></td><td></td><td></td>
-                    </tr>
-                  ))}
-                  <tr>
-                    <td colSpan="4" className="text-right font-bold uppercase">Total:</td>
-                    <td className="font-bold bg-gray-50">{grandTotal.toFixed(2)}</td>
-                  </tr>
-                </tbody>
-              </table>
-
-              <div className="mt-1">
-                <p className="font-bold text-[7.5pt] mb-0">Reflection on Service Activity/Work (attach additional pages if necessary):</p>
-                <p className="text-[6.5pt] italic mb-0.5">Attach a copy of your pay stub for work hours if applicable. Complete the reflection below...</p>
-                <div className="reflection-box">
-                  {[...Array(7)].map((_, i) => <div key={i} className="reflection-line"></div>)}
-                </div>
-              </div>
-
-              <p className="text-[7pt] mt-2 font-bold leading-tight">By signing below, I certify that all information on this document is true and correct. I understand that if I am found to have given false testimony about these hours that the hours will be revoked and endanger my eligibility for the Bright Futures Scholarship.</p>
-
-              <div className="mt-3 flex justify-between">
-                <div className="text-[8pt]">Student Signature: _______________________ Date: ________</div>
-                <div className="text-[8pt]">Parent Signature: ________________________ Date: ________</div>
-              </div>
-              <p className="text-[5.5pt] mt-1 text-gray-400">Revised 8/2023</p>
-            </div>
-          );
-        })}
-      </div>
 
       {/* PRINT ALL BADGES */}
       <div id="print-all-badges">

--- a/frontend/src/pages/StudentsPage.jsx
+++ b/frontend/src/pages/StudentsPage.jsx
@@ -6,7 +6,6 @@ import { collection, onSnapshot, addDoc, serverTimestamp, query, where, doc } fr
 import { ref, getDownloadURL } from 'firebase/storage';
 import { generateFilledPdf, mergePdfs, openPdfForPrinting } from '../utils/pdfTemplateUtils';
 import { useEvent } from '../contexts/EventContext';
-import Header from '../components/common/Header';
 import Button from '../components/common/Button';
 import Spinner from '../components/common/Spinner';
 import PrintableBadge from '../components/common/PrintableBadge';
@@ -380,14 +379,12 @@ export default function StudentsPage() {
 
   if (loading) return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <div className="p-20 text-center"><Spinner size="lg" /></div>
     </div>
   );
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <div className="p-6 max-w-7xl mx-auto">
       <style>
         {`

--- a/frontend/src/pages/StudentsPage.test.jsx
+++ b/frontend/src/pages/StudentsPage.test.jsx
@@ -7,7 +7,22 @@ import StudentsPage from './StudentsPage';
 // Mock Firebase
 vi.mock('../utils/firebase', () => ({
   db: {},
-  functions: {}
+  functions: {},
+  storage: {},
+}));
+
+// Mock Firebase Storage
+vi.mock('firebase/storage', () => ({
+  ref: vi.fn(),
+  getDownloadURL: vi.fn(() => Promise.resolve('https://storage.example.com/template.pdf')),
+}));
+
+// Mock pdfTemplateUtils
+vi.mock('../utils/pdfTemplateUtils', () => ({
+  generateFilledPdf: vi.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
+  mergePdfs: vi.fn((arr) => Promise.resolve(arr[0] || new Uint8Array([1, 2, 3]))),
+  openPdfForPrinting: vi.fn(),
+  downloadPdf: vi.fn(),
 }));
 
 // Mock data
@@ -26,51 +41,52 @@ const mockTimeEntries = [
 let studentsUnsubscribe = vi.fn();
 let entriesUnsubscribe = vi.fn();
 
-vi.mock('firebase/firestore', () => {
-  // Helper to determine which collection this is
-  const getCollectionPath = (queryOrRef) => {
-    if (queryOrRef?.path) return queryOrRef.path;
-    if (queryOrRef?._query?.path) return queryOrRef._query.path;
-    if (queryOrRef?._collectionPath) return queryOrRef._collectionPath;
-    return 'unknown';
-  };
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn((db, path) => ({ _collPath: path })),
+  doc: vi.fn((db, ...args) => ({ _isDoc: true })),
+  onSnapshot: vi.fn((queryOrRef, callback) => {
+    if (queryOrRef?._isDoc) {
+      // Document snapshot (settings/pdfDefaults)
+      callback({ exists: () => false, data: () => null });
+      return vi.fn();
+    }
 
-  return {
-    collection: vi.fn((db, path) => ({ path, _collectionPath: path })),
-    onSnapshot: vi.fn((queryOrRef, callback) => {
-      const path = getCollectionPath(queryOrRef);
+    const path = queryOrRef?._collPath;
 
-      if (path === 'students') {
-        // Simulate students data - use queueMicrotask for immediate async execution
-        queueMicrotask(() => {
-          callback({
-            docs: [
-              { id: 'student1', data: () => ({ id: 'student1', firstName: 'John', lastName: 'Doe', schoolName: 'Central High', gradeLevel: '10', gradYear: '2027', overrideHours: 0 }) },
-              { id: 'student2', data: () => ({ id: 'student2', firstName: 'Jane', lastName: 'Smith', schoolName: 'West High', gradeLevel: '11', gradYear: '2026', overrideHours: 0 }) },
-              { id: 'student3', data: () => ({ id: 'student3', firstName: 'Bob', lastName: 'Johnson', schoolName: 'East High', gradeLevel: '12', gradYear: '2025', overrideHours: 0 }) },
-            ]
-          });
+    if (path === 'pdfTemplates') {
+      callback({ docs: [] });
+      return vi.fn();
+    }
+
+    if (path === 'students') {
+      queueMicrotask(() => {
+        callback({
+          docs: [
+            { id: 'student1', data: () => ({ id: 'student1', firstName: 'John', lastName: 'Doe', schoolName: 'Central High', gradeLevel: '10', gradYear: '2027', overrideHours: 0 }) },
+            { id: 'student2', data: () => ({ id: 'student2', firstName: 'Jane', lastName: 'Smith', schoolName: 'West High', gradeLevel: '11', gradYear: '2026', overrideHours: 0 }) },
+            { id: 'student3', data: () => ({ id: 'student3', firstName: 'Bob', lastName: 'Johnson', schoolName: 'East High', gradeLevel: '12', gradYear: '2025', overrideHours: 0 }) },
+          ]
         });
-        return vi.fn();
-      } else {
-        // Simulate time entries data
-        queueMicrotask(() => {
-          callback({
-            docs: [
-              { id: 'entry0', data: () => ({ studentId: 'student1', eventId: 'event123', activityId: 'activity1', checkInTime: { seconds: 1704096000, toDate: () => new Date('2024-01-01T08:00:00') }, checkOutTime: { seconds: 1704110400, toDate: () => new Date('2024-01-01T12:00:00') } }) },
-              { id: 'entry1', data: () => ({ studentId: 'student2', eventId: 'event123', activityId: 'activity1', checkInTime: { seconds: 1704096000, toDate: () => new Date('2024-01-01T08:00:00') }, checkOutTime: { seconds: 1704110400, toDate: () => new Date('2024-01-01T12:00:00') } }) },
-            ]
-          });
-        });
-        return vi.fn();
-      }
-    }),
-    query: vi.fn((ref) => ({ ...ref, _query: ref, _collectionPath: ref.path || ref._collectionPath })),
-    where: vi.fn(),
-    addDoc: vi.fn().mockResolvedValue({ id: 'newStudent' }),
-    serverTimestamp: vi.fn(() => ({ seconds: Date.now() / 1000 }))
-  };
-});
+      });
+      return vi.fn();
+    }
+
+    // timeEntries or other
+    queueMicrotask(() => {
+      callback({
+        docs: [
+          { id: 'entry0', data: () => ({ studentId: 'student1', eventId: 'event123', activityId: 'activity1', checkInTime: { seconds: 1704096000, toDate: () => new Date('2024-01-01T08:00:00') }, checkOutTime: { seconds: 1704110400, toDate: () => new Date('2024-01-01T12:00:00') } }) },
+          { id: 'entry1', data: () => ({ studentId: 'student2', eventId: 'event123', activityId: 'activity1', checkInTime: { seconds: 1704096000, toDate: () => new Date('2024-01-01T08:00:00') }, checkOutTime: { seconds: 1704110400, toDate: () => new Date('2024-01-01T12:00:00') } }) },
+        ]
+      });
+    });
+    return vi.fn();
+  }),
+  query: vi.fn((ref) => ref),
+  where: vi.fn(() => ({})),
+  addDoc: vi.fn().mockResolvedValue({ id: 'newStudent' }),
+  serverTimestamp: vi.fn(() => ({ seconds: Date.now() / 1000 })),
+}));
 
 // Mock AuthContext
 vi.mock('../contexts/AuthContext', () => ({

--- a/frontend/src/pages/UsersPage.jsx
+++ b/frontend/src/pages/UsersPage.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { functions } from '../utils/firebase';
 import { httpsCallable } from 'firebase/functions';
 import { useAuth } from '../contexts/AuthContext';
-import Header from '../components/common/Header';
 import Button from '../components/common/Button';
 import Spinner from '../components/common/Spinner';
 import Modal from '../components/common/Modal';
@@ -214,7 +213,6 @@ export default function UsersPage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50">
-        <Header />
         <div className="p-20 text-center">
           <Spinner size="lg" />
         </div>
@@ -224,7 +222,6 @@ export default function UsersPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <div className="p-6 max-w-7xl mx-auto">
         {/* PAGE HEADER */}
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-4">

--- a/frontend/src/utils/pdfTemplateUtils.js
+++ b/frontend/src/utils/pdfTemplateUtils.js
@@ -262,6 +262,38 @@ export async function generateFilledPdf(templatePdfBytes, fields, data) {
 }
 
 /**
+ * Merges multiple PDF byte arrays into a single PDF document.
+ */
+export async function mergePdfs(pdfBytesArray) {
+  const mergedDoc = await PDFDocument.create();
+  for (const pdfBytes of pdfBytesArray) {
+    const srcDoc = await PDFDocument.load(pdfBytes);
+    const copiedPages = await mergedDoc.copyPages(srcDoc, srcDoc.getPageIndices());
+    copiedPages.forEach(page => mergedDoc.addPage(page));
+  }
+  return mergedDoc.save();
+}
+
+/**
+ * Opens PDF bytes in a new browser tab so the user sees the native print dialog.
+ * Falls back to a download if the popup is blocked.
+ */
+export function openPdfForPrinting(pdfBytes, filename = 'service-log.pdf') {
+  const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  const win = window.open(url, '_blank');
+  if (!win) {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
+  setTimeout(() => URL.revokeObjectURL(url), 60000);
+}
+
+/**
  * Triggers a browser download of a PDF from bytes.
  */
 export function downloadPdf(pdfBytes, filename) {

--- a/frontend/src/utils/pdfTemplateUtils.test.js
+++ b/frontend/src/utils/pdfTemplateUtils.test.js
@@ -7,6 +7,8 @@ import {
   resolveActivityColumnValue,
   resolveDetailColumnValue,
   generateFilledPdf,
+  mergePdfs,
+  openPdfForPrinting,
   downloadPdf,
   getPdfPageDimensions,
 } from './pdfTemplateUtils';
@@ -682,6 +684,89 @@ describe('pdfTemplateUtils', () => {
 
       const result = await generateFilledPdf(templatePdfBytes, fields, data);
       expect(result).toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  describe('mergePdfs', () => {
+    it('should merge multiple PDFs into one', async () => {
+      const pdfDoc1 = await PDFDocument.create();
+      pdfDoc1.addPage([612, 792]);
+      const bytes1 = await pdfDoc1.save();
+
+      const pdfDoc2 = await PDFDocument.create();
+      pdfDoc2.addPage([612, 792]);
+      pdfDoc2.addPage([612, 792]);
+      const bytes2 = await pdfDoc2.save();
+
+      const merged = await mergePdfs([bytes1, bytes2]);
+      expect(merged).toBeInstanceOf(Uint8Array);
+
+      const mergedDoc = await PDFDocument.load(merged);
+      expect(mergedDoc.getPageCount()).toBe(3);
+    });
+
+    it('should handle a single PDF', async () => {
+      const pdfDoc = await PDFDocument.create();
+      pdfDoc.addPage([612, 792]);
+      const bytes = await pdfDoc.save();
+
+      const merged = await mergePdfs([bytes]);
+      expect(merged).toBeInstanceOf(Uint8Array);
+
+      const mergedDoc = await PDFDocument.load(merged);
+      expect(mergedDoc.getPageCount()).toBe(1);
+    });
+
+    it('should produce a valid PDF for empty input', async () => {
+      const merged = await mergePdfs([]);
+      expect(merged).toBeInstanceOf(Uint8Array);
+      // Should be a valid loadable PDF document
+      const mergedDoc = await PDFDocument.load(merged);
+      expect(mergedDoc.getPageCount()).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('openPdfForPrinting', () => {
+    it('should open a new window with a blob URL', () => {
+      const mockOpen = vi.fn(() => ({ /* non-null window */ }));
+      const mockCreateObjectURL = vi.fn(() => 'blob:test-print-url');
+      const mockRevokeObjectURL = vi.fn();
+
+      global.URL.createObjectURL = mockCreateObjectURL;
+      global.URL.revokeObjectURL = mockRevokeObjectURL;
+      global.window.open = mockOpen;
+
+      const pdfBytes = new Uint8Array([1, 2, 3]);
+      openPdfForPrinting(pdfBytes, 'test.pdf');
+
+      expect(mockCreateObjectURL).toHaveBeenCalled();
+      expect(mockOpen).toHaveBeenCalledWith('blob:test-print-url', '_blank');
+    });
+
+    it('should fall back to download when popup is blocked', () => {
+      const mockOpen = vi.fn(() => null); // simulates blocked popup
+      const mockClick = vi.fn();
+      const mockAppendChild = vi.spyOn(document.body, 'appendChild').mockImplementation(() => {});
+      const mockRemoveChild = vi.spyOn(document.body, 'removeChild').mockImplementation(() => {});
+      const mockCreateObjectURL = vi.fn(() => 'blob:fallback-url');
+      const mockRevokeObjectURL = vi.fn();
+
+      global.URL.createObjectURL = mockCreateObjectURL;
+      global.URL.revokeObjectURL = mockRevokeObjectURL;
+      global.window.open = mockOpen;
+
+      const mockLink = { href: '', download: '', click: mockClick };
+      vi.spyOn(document, 'createElement').mockReturnValue(mockLink);
+
+      const pdfBytes = new Uint8Array([1, 2, 3]);
+      openPdfForPrinting(pdfBytes, 'fallback.pdf');
+
+      expect(mockLink.download).toBe('fallback.pdf');
+      expect(mockClick).toHaveBeenCalled();
+
+      mockAppendChild.mockRestore();
+      mockRemoveChild.mockRestore();
+      document.createElement.mockRestore?.();
     });
   });
 


### PR DESCRIPTION
## Summary
- Move admin routes into a shared left-sidebar workspace shell
- Add an active-event context switcher that loads all events and updates selection immediately
- Replace the settings flyout with a full Settings workspace and tabs for Events, Users, and PDF Templates
- Give scanner routes a kiosk-style header with only an Exit Scan Mode action

## Verification
- npm run build
- npm test