### PR TITLE
feat: per-event student roster and system-wide student management

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import CreateEventPage from './pages/CreateEventPage';
 import StudentDetailPage from './pages/StudentDetailPage';
 import UsersPage from './pages/UsersPage';
 import PdfTemplatesPage from './pages/PdfTemplatesPage';
+import EventStudentsPage from './pages/EventStudentsPage';
 
 // Loading Spinner Component
 function LoadingSpinner() {
@@ -106,6 +107,7 @@ function AdminLayout() {
 function SettingsLayout() {
   const location = useLocation();
   const tabs = [
+    { path: '/admin/settings/students', label: 'Students' },
     { path: '/admin/settings/events', label: 'Events' },
     { path: '/admin/settings/users', label: 'Users' },
     { path: '/admin/settings/pdf-templates', label: 'PDF Templates' },
@@ -179,15 +181,18 @@ function App() {
               <Route index element={<AdminDashboardPage />} />
               <Route path="daily-review" element={<DailyReviewPage />} />
               <Route path="forms" element={<FormGenerationPage />} />
-              <Route path="students" element={<StudentsPage />} />
-              <Route path="students/:studentId" element={<StudentDetailPage />} />
+              <Route path="students" element={<Navigate to="/admin/settings/students" replace />} />
+              <Route path="students/:studentId" element={<Navigate to="/admin/settings/students/:studentId" replace />} />
               <Route path="events" element={<Navigate to="/admin/settings/events" replace />} />
               <Route path="events/new" element={<Navigate to="/admin/settings/events/new" replace />} />
               <Route path="users" element={<Navigate to="/admin/settings/users" replace />} />
               <Route path="settings" element={<SettingsLayout />}>
-                <Route index element={<Navigate to="events" replace />} />
+                <Route index element={<Navigate to="students" replace />} />
+                <Route path="students" element={<StudentsPage />} />
+                <Route path="students/:studentId" element={<StudentDetailPage />} />
                 <Route path="events" element={<EventsPage />} />
                 <Route path="events/new" element={<CreateEventPage />} />
+                <Route path="events/:eventId/students" element={<EventStudentsPage />} />
                 <Route path="users" element={<UsersPage />} />
                 <Route path="pdf-templates" element={<PdfTemplatesPage />} />
               </Route>

--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -40,7 +40,6 @@ export default function Header({
 
   const operationsNav = [
     { path: '/admin', label: 'Dashboard', exact: true },
-    { path: '/admin/students', label: 'Students' },
     { path: '/admin/daily-review', label: 'Daily Review' },
   ];
 

--- a/frontend/src/components/common/Header.test.jsx
+++ b/frontend/src/components/common/Header.test.jsx
@@ -60,10 +60,11 @@ describe('Header', () => {
     renderWithRouter(<Header />);
 
     expect(screen.getAllByRole('link', { name: 'Dashboard' }).some(link => link.getAttribute('href') === '/admin')).toBe(true);
-    expect(screen.getAllByRole('link', { name: 'Students' }).some(link => link.getAttribute('href') === '/admin/students')).toBe(true);
     expect(screen.getAllByRole('link', { name: 'Daily Review' }).some(link => link.getAttribute('href') === '/admin/daily-review')).toBe(true);
     expect(screen.getByRole('link', { name: /settings/i })).toHaveAttribute('href', '/admin/settings');
     expect(screen.queryByRole('link', { name: 'Events' })).not.toBeInTheDocument();
+    // Students is now under Settings, not in the Operations nav
+    expect(screen.queryByRole('link', { name: 'Students' })).not.toBeInTheDocument();
   });
 
   it('highlights settings when a settings route is active', () => {
@@ -73,10 +74,10 @@ describe('Header', () => {
   });
 
   it('highlights active operational links', () => {
-    renderWithRouter(<Header />, { route: '/admin/students' });
+    renderWithRouter(<Header />, { route: '/admin/daily-review' });
 
-    const studentsLinks = screen.getAllByRole('link', { name: 'Students' });
-    expect(studentsLinks.some(link => link.classList.contains('bg-primary-50'))).toBe(true);
+    const dailyReviewLinks = screen.getAllByRole('link', { name: 'Daily Review' });
+    expect(dailyReviewLinks.some(link => link.classList.contains('bg-primary-50'))).toBe(true);
   });
 
   it('switches the active event from the context switcher', async () => {
@@ -100,7 +101,6 @@ describe('Header', () => {
     renderWithRouter(<Header showNavTabs={false} />);
 
     expect(screen.queryByRole('link', { name: 'Daily Review' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'Students' })).not.toBeInTheDocument();
   });
 
   it('hides event indicator text when showEventIndicator is false', () => {
@@ -132,7 +132,7 @@ describe('Header', () => {
     await user.click(screen.getByRole('button', { name: /open menu/i }));
     expect(screen.getByRole('button', { name: /close menu/i })).toHaveAttribute('aria-expanded', 'true');
 
-    await user.click(screen.getAllByRole('link', { name: 'Students' })[0]);
+    await user.click(screen.getAllByRole('link', { name: 'Daily Review' })[0]);
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /open menu/i })).toBeInTheDocument();

--- a/frontend/src/pages/EventStudentsPage.jsx
+++ b/frontend/src/pages/EventStudentsPage.jsx
@@ -1,0 +1,400 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { db } from '../utils/firebase';
+import {
+    collection,
+    onSnapshot,
+    addDoc,
+    getDocs,
+    query,
+    where,
+    serverTimestamp,
+} from 'firebase/firestore';
+import { useAuth } from '../contexts/AuthContext';
+import Button from '../components/common/Button';
+import Spinner from '../components/common/Spinner';
+
+export default function EventStudentsPage() {
+    const { eventId } = useParams();
+    const { user } = useAuth();
+
+    const [event, setEvent] = useState(null);
+    const [allStudents, setAllStudents] = useState([]);
+    const [eventStudentIds, setEventStudentIds] = useState(new Set());
+    const [checkedInStudentIds, setCheckedInStudentIds] = useState(new Set());
+    const [loading, setLoading] = useState(true);
+
+    const [addStudentModal, setAddStudentModal] = useState(false);
+    const [addForm, setAddForm] = useState({ firstName: '', lastName: '', schoolName: '', gradeLevel: '', gradYear: '' });
+    const [addingSaving, setAddingSaving] = useState(false);
+
+    const [importModal, setImportModal] = useState(false);
+    const [importSearch, setImportSearch] = useState('');
+    const [importSelected, setImportSelected] = useState(new Set());
+    const [importSaving, setImportSaving] = useState(false);
+
+    // Load event
+    useEffect(() => {
+        if (!eventId) return;
+        const unsub = onSnapshot(collection(db, 'events'), snap => {
+            const found = snap.docs.find(d => d.id === eventId);
+            if (found) setEvent({ id: found.id, ...found.data() });
+        });
+        return () => unsub();
+    }, [eventId]);
+
+    // Load all students
+    useEffect(() => {
+        const unsub = onSnapshot(collection(db, 'students'), snap => {
+            setAllStudents(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+        });
+        return () => unsub();
+    }, []);
+
+    // Load explicit eventStudents associations
+    useEffect(() => {
+        if (!eventId) return;
+        const q = query(collection(db, 'eventStudents'), where('eventId', '==', eventId));
+        const unsub = onSnapshot(q, snap => {
+            setEventStudentIds(new Set(snap.docs.map(d => d.data().studentId)));
+        });
+        return () => unsub();
+    }, [eventId]);
+
+    // Load students who have checked in at least once
+    useEffect(() => {
+        if (!eventId) return;
+        const q = query(collection(db, 'timeEntries'), where('eventId', '==', eventId));
+        const unsub = onSnapshot(q, snap => {
+            const ids = new Set();
+            snap.docs.forEach(d => {
+                if (!d.data().isVoided) ids.add(d.data().studentId);
+            });
+            setCheckedInStudentIds(ids);
+            setLoading(false);
+        });
+        return () => unsub();
+    }, [eventId]);
+
+    // Students visible in this event: explicitly added OR checked in at least once
+    const eventStudents = useMemo(() => {
+        return allStudents
+            .filter(s => eventStudentIds.has(s.id) || checkedInStudentIds.has(s.id))
+            .sort((a, b) => a.lastName.localeCompare(b.lastName));
+    }, [allStudents, eventStudentIds, checkedInStudentIds]);
+
+    // Students not yet associated with this event (for import modal)
+    const importableStudents = useMemo(() => {
+        return allStudents
+            .filter(s => !eventStudentIds.has(s.id) && !checkedInStudentIds.has(s.id))
+            .filter(s => {
+                if (!importSearch.trim()) return true;
+                return `${s.firstName} ${s.lastName}`.toLowerCase().includes(importSearch.toLowerCase());
+            })
+            .sort((a, b) => a.lastName.localeCompare(b.lastName));
+    }, [allStudents, eventStudentIds, checkedInStudentIds, importSearch]);
+
+    const handleAddStudent = async (e) => {
+        e.preventDefault();
+        setAddingSaving(true);
+        try {
+            const docRef = await addDoc(collection(db, 'students'), {
+                ...addForm,
+                overrideHours: 0,
+                createdAt: serverTimestamp(),
+            });
+            await addDoc(collection(db, 'eventStudents'), {
+                eventId,
+                studentId: docRef.id,
+                addedAt: serverTimestamp(),
+                addedBy: user?.uid || 'admin',
+            });
+            setAddStudentModal(false);
+            setAddForm({ firstName: '', lastName: '', schoolName: '', gradeLevel: '', gradYear: '' });
+        } catch (err) {
+            console.error('Error adding student:', err);
+        } finally {
+            setAddingSaving(false);
+        }
+    };
+
+    const handleImport = async () => {
+        if (importSelected.size === 0) return;
+        setImportSaving(true);
+        try {
+            await Promise.all(
+                [...importSelected].map(studentId =>
+                    addDoc(collection(db, 'eventStudents'), {
+                        eventId,
+                        studentId,
+                        addedAt: serverTimestamp(),
+                        addedBy: user?.uid || 'admin',
+                    })
+                )
+            );
+            setImportModal(false);
+            setImportSelected(new Set());
+            setImportSearch('');
+        } catch (err) {
+            console.error('Error importing students:', err);
+        } finally {
+            setImportSaving(false);
+        }
+    };
+
+    const toggleImportSelect = (id) => {
+        setImportSelected(prev => {
+            const next = new Set(prev);
+            next.has(id) ? next.delete(id) : next.add(id);
+            return next;
+        });
+    };
+
+    if (loading) {
+        return (
+            <div className="min-h-screen bg-gray-50">
+                <div className="p-20 text-center"><Spinner size="lg" /></div>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            {/* Page header */}
+            <div className="mb-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                <div>
+                    <div className="flex items-center gap-2 text-xs text-gray-400 font-bold uppercase tracking-widest mb-1">
+                        <Link to="/admin/settings/events" className="hover:text-primary-600">Events</Link>
+                        <span>/</span>
+                        <span className="text-gray-600">{event?.name || eventId}</span>
+                        <span>/</span>
+                        <span className="text-gray-600">Students</span>
+                    </div>
+                    <h2 className="text-2xl font-black text-gray-900 tracking-tight">
+                        {event?.name || 'Event'} — Students
+                    </h2>
+                    <p className="text-gray-500 text-sm font-medium mt-1">
+                        {eventStudents.length} student{eventStudents.length !== 1 ? 's' : ''} associated with this event
+                    </p>
+                </div>
+                <div className="flex gap-2 shrink-0">
+                    {allStudents.length > eventStudents.length && (
+                        <Button
+                            variant="secondary"
+                            onClick={() => { setImportModal(true); setImportSearch(''); setImportSelected(new Set()); }}
+                        >
+                            Import from System
+                        </Button>
+                    )}
+                    <Button variant="primary" onClick={() => setAddStudentModal(true)}>
+                        + Add Student
+                    </Button>
+                </div>
+            </div>
+
+            {/* Student list */}
+            {eventStudents.length === 0 ? (
+                <div className="bg-white rounded-2xl shadow-sm border p-12 text-center text-gray-400">
+                    <p className="text-lg font-bold mb-2">No students yet</p>
+                    <p className="text-sm">Add a new student or import existing ones from the system.</p>
+                </div>
+            ) : (
+                <div className="bg-white rounded-2xl shadow-sm border overflow-hidden">
+                    <table className="min-w-full divide-y divide-gray-200">
+                        <thead className="bg-gray-50">
+                            <tr className="text-left text-xs font-bold text-gray-400 uppercase tracking-wider">
+                                <th className="px-6 py-4">Name</th>
+                                <th className="px-6 py-4">School</th>
+                                <th className="px-6 py-4">Grade</th>
+                                <th className="px-6 py-4">Grad Year</th>
+                                <th className="px-6 py-4">Status</th>
+                                <th className="px-6 py-4"></th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-100">
+                            {eventStudents.map(s => (
+                                <tr key={s.id} className="hover:bg-gray-50 transition-colors">
+                                    <td className="px-6 py-4 font-bold text-gray-900">
+                                        {s.firstName} {s.lastName}
+                                    </td>
+                                    <td className="px-6 py-4 text-sm text-gray-600">{s.schoolName || '—'}</td>
+                                    <td className="px-6 py-4 text-sm text-gray-600">{s.gradeLevel || '—'}</td>
+                                    <td className="px-6 py-4 text-sm text-gray-600">{s.gradYear || '—'}</td>
+                                    <td className="px-6 py-4">
+                                        {checkedInStudentIds.has(s.id) ? (
+                                            <span className="inline-flex items-center gap-1 text-xs font-bold text-green-700 bg-green-50 px-2 py-0.5 rounded-full border border-green-100">
+                                                Checked In
+                                            </span>
+                                        ) : (
+                                            <span className="inline-flex items-center gap-1 text-xs font-bold text-gray-500 bg-gray-50 px-2 py-0.5 rounded-full border border-gray-100">
+                                                Added
+                                            </span>
+                                        )}
+                                    </td>
+                                    <td className="px-6 py-4 text-right">
+                                        <Link
+                                            to={`/admin/settings/students/${s.id}`}
+                                            className="text-xs font-bold text-primary-600 hover:underline"
+                                        >
+                                            View Details
+                                        </Link>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+            {/* Add Student Modal */}
+            {addStudentModal && (
+                <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50 backdrop-blur-sm">
+                    <div className="bg-white rounded-3xl shadow-2xl max-w-md w-full p-8 max-h-[85vh] overflow-y-auto">
+                        <h2 className="text-2xl font-black mb-6 text-gray-900">Add New Student</h2>
+                        <form onSubmit={handleAddStudent} className="space-y-4">
+                            <div className="grid grid-cols-2 gap-4">
+                                <div>
+                                    <label className="block text-[10px] font-black text-gray-400 uppercase mb-1">First Name</label>
+                                    <input
+                                        className="w-full border border-gray-200 rounded-xl p-3 focus:ring-2 focus:ring-primary-500 outline-none"
+                                        value={addForm.firstName}
+                                        onChange={e => setAddForm(f => ({ ...f, firstName: e.target.value }))}
+                                        required
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-[10px] font-black text-gray-400 uppercase mb-1">Last Name</label>
+                                    <input
+                                        className="w-full border border-gray-200 rounded-xl p-3 focus:ring-2 focus:ring-primary-500 outline-none"
+                                        value={addForm.lastName}
+                                        onChange={e => setAddForm(f => ({ ...f, lastName: e.target.value }))}
+                                        required
+                                    />
+                                </div>
+                            </div>
+                            <div>
+                                <label className="block text-[10px] font-black text-gray-400 uppercase mb-1">School Name</label>
+                                <input
+                                    className="w-full border border-gray-200 rounded-xl p-3 focus:ring-2 focus:ring-primary-500 outline-none"
+                                    value={addForm.schoolName}
+                                    onChange={e => setAddForm(f => ({ ...f, schoolName: e.target.value }))}
+                                />
+                            </div>
+                            <div className="grid grid-cols-2 gap-4">
+                                <div>
+                                    <label className="block text-[10px] font-black text-gray-400 uppercase mb-1">Grade Level</label>
+                                    <input
+                                        className="w-full border border-gray-200 rounded-xl p-3 focus:ring-2 focus:ring-primary-500 outline-none"
+                                        value={addForm.gradeLevel}
+                                        onChange={e => setAddForm(f => ({ ...f, gradeLevel: e.target.value }))}
+                                        type="number"
+                                        min="9"
+                                        max="12"
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-[10px] font-black text-gray-400 uppercase mb-1">Grad Year</label>
+                                    <input
+                                        className="w-full border border-gray-200 rounded-xl p-3 focus:ring-2 focus:ring-primary-500 outline-none"
+                                        value={addForm.gradYear}
+                                        onChange={e => setAddForm(f => ({ ...f, gradYear: e.target.value }))}
+                                        placeholder="e.g. 2027"
+                                    />
+                                </div>
+                            </div>
+                            <div className="flex gap-3 pt-4">
+                                <Button type="submit" className="flex-1" disabled={addingSaving} loading={addingSaving}>
+                                    Add Student
+                                </Button>
+                                <button
+                                    type="button"
+                                    onClick={() => setAddStudentModal(false)}
+                                    className="px-6 py-3 text-gray-400 font-bold hover:bg-gray-100 rounded-2xl transition-colors text-sm"
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            )}
+
+            {/* Import from System Modal */}
+            {importModal && (
+                <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50 backdrop-blur-sm">
+                    <div className="bg-white rounded-3xl shadow-2xl max-w-lg w-full p-8 max-h-[85vh] flex flex-col">
+                        <div className="flex justify-between items-start mb-4">
+                            <div>
+                                <h2 className="text-2xl font-black text-gray-900">Import Students</h2>
+                                <p className="text-sm text-gray-500 mt-1">Add existing students from the system to this event.</p>
+                            </div>
+                            <button
+                                onClick={() => setImportModal(false)}
+                                className="text-gray-400 hover:text-gray-600 text-2xl leading-none ml-4"
+                                aria-label="Close"
+                            >
+                                ×
+                            </button>
+                        </div>
+
+                        <input
+                            type="search"
+                            placeholder="Search by name…"
+                            value={importSearch}
+                            onChange={e => setImportSearch(e.target.value)}
+                            className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-primary-500 outline-none mb-4"
+                        />
+
+                        <div className="flex-1 overflow-y-auto min-h-0 border border-gray-100 rounded-xl">
+                            {importableStudents.length === 0 ? (
+                                <p className="p-6 text-center text-gray-400 text-sm">
+                                    {importSearch ? 'No matches found.' : 'All students are already in this event.'}
+                                </p>
+                            ) : (
+                                <ul className="divide-y divide-gray-50">
+                                    {importableStudents.map(s => (
+                                        <li key={s.id}>
+                                            <label className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 cursor-pointer">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={importSelected.has(s.id)}
+                                                    onChange={() => toggleImportSelect(s.id)}
+                                                    className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                                                />
+                                                <div>
+                                                    <p className="text-sm font-bold text-gray-900">{s.firstName} {s.lastName}</p>
+                                                    <p className="text-xs text-gray-500">{s.schoolName} {s.gradYear ? `· ${s.gradYear}` : ''}</p>
+                                                </div>
+                                            </label>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
+
+                        <div className="flex items-center justify-between gap-3 mt-4 pt-4 border-t border-gray-100">
+                            <span className="text-sm text-gray-500">
+                                {importSelected.size > 0 ? `${importSelected.size} selected` : 'Select students to import'}
+                            </span>
+                            <div className="flex gap-2">
+                                <button
+                                    onClick={() => setImportModal(false)}
+                                    className="px-4 py-2 text-gray-400 font-bold hover:bg-gray-100 rounded-xl transition-colors text-sm"
+                                >
+                                    Cancel
+                                </button>
+                                <Button
+                                    onClick={handleImport}
+                                    disabled={importSelected.size === 0 || importSaving}
+                                    loading={importSaving}
+                                >
+                                    Add {importSelected.size > 0 ? `${importSelected.size} ` : ''}Student{importSelected.size !== 1 ? 's' : ''}
+                                </Button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/pages/EventStudentsPage.test.jsx
+++ b/frontend/src/pages/EventStudentsPage.test.jsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import EventStudentsPage from './EventStudentsPage';
+
+vi.mock('../utils/firebase', () => ({ db: {} }));
+
+const mockStudents = [
+    { id: 'student1', firstName: 'Alice', lastName: 'Adams', schoolName: 'Central High', gradeLevel: '10', gradYear: '2027' },
+    { id: 'student2', firstName: 'Bob', lastName: 'Brown', schoolName: 'West High', gradeLevel: '11', gradYear: '2026' },
+    { id: 'student3', firstName: 'Charlie', lastName: 'Clark', schoolName: 'East High', gradeLevel: '12', gradYear: '2025' },
+];
+
+const mockEvents = [
+    { id: 'event123', name: 'VBS 2026', organizationName: 'Church' },
+];
+
+let onSnapshotCalls = [];
+let addDocMock;
+
+vi.mock('firebase/firestore', () => ({
+    collection: vi.fn((db, path) => ({ _collPath: path })),
+    query: vi.fn((ref) => ref),
+    where: vi.fn(() => ({})),
+    onSnapshot: vi.fn((queryOrRef, callback) => {
+        const path = queryOrRef?._collPath;
+
+        if (path === 'events') {
+            queueMicrotask(() => callback({ docs: mockEvents.map(e => ({ id: e.id, data: () => e })) }));
+        } else if (path === 'students') {
+            queueMicrotask(() => callback({ docs: mockStudents.map(s => ({ id: s.id, data: () => s })) }));
+        } else if (path === 'eventStudents') {
+            // Only student1 explicitly added to event
+            queueMicrotask(() => callback({ docs: [{ id: 'es1', data: () => ({ eventId: 'event123', studentId: 'student1' }) }] }));
+        } else if (path === 'timeEntries') {
+            // student2 checked in via time entries
+            queueMicrotask(() => callback({ docs: [
+                { id: 'te1', data: () => ({ eventId: 'event123', studentId: 'student2', isVoided: false }) }
+            ] }));
+        } else {
+            queueMicrotask(() => callback({ docs: [] }));
+        }
+
+        const unsub = vi.fn();
+        onSnapshotCalls.push(unsub);
+        return unsub;
+    }),
+    addDoc: vi.fn().mockResolvedValue({ id: 'newDoc' }),
+    getDocs: vi.fn().mockResolvedValue({ docs: [] }),
+    serverTimestamp: vi.fn(() => ({})),
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+    useAuth: () => ({ user: { uid: 'admin123' } }),
+}));
+
+const renderPage = () => render(
+    <MemoryRouter initialEntries={['/admin/settings/events/event123/students']}>
+        <Routes>
+            <Route path="/admin/settings/events/:eventId/students" element={<EventStudentsPage />} />
+            <Route path="/admin/settings/events" element={<div>Events</div>} />
+        </Routes>
+    </MemoryRouter>
+);
+
+describe('EventStudentsPage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        onSnapshotCalls = [];
+    });
+
+    it('renders page heading with event name', async () => {
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByText(/VBS 2026 — Students/i)).toBeInTheDocument();
+        });
+    });
+
+    it('shows students who are explicitly added to event', async () => {
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByText('Alice Adams')).toBeInTheDocument();
+        });
+    });
+
+    it('shows students who have checked in at least once', async () => {
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByText('Bob Brown')).toBeInTheDocument();
+        });
+    });
+
+    it('does not show students not associated with the event', async () => {
+        renderPage();
+        await waitFor(() => {
+            expect(screen.queryByText('Charlie Clark')).not.toBeInTheDocument();
+        });
+    });
+
+    it('shows status badge "Checked In" for checked-in students', async () => {
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByText('Checked In')).toBeInTheDocument();
+        });
+    });
+
+    it('shows status badge "Added" for explicitly added students without check-in', async () => {
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByText('Added')).toBeInTheDocument();
+        });
+    });
+
+    it('shows Import from System button when importable students exist', async () => {
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /Import from System/i })).toBeInTheDocument();
+        });
+    });
+
+    it('opens Add Student modal on button click', async () => {
+        const user = userEvent.setup();
+        renderPage();
+        await waitFor(() => screen.getByRole('button', { name: /\+ Add Student/i }));
+        await user.click(screen.getByRole('button', { name: /\+ Add Student/i }));
+        expect(screen.getByText('Add New Student')).toBeInTheDocument();
+    });
+
+    it('opens Import modal on button click', async () => {
+        const user = userEvent.setup();
+        renderPage();
+        await waitFor(() => screen.getByRole('button', { name: /Import from System/i }));
+        await user.click(screen.getByRole('button', { name: /Import from System/i }));
+        expect(screen.getByText('Import Students')).toBeInTheDocument();
+    });
+
+    it('import modal shows only students not yet in event', async () => {
+        const user = userEvent.setup();
+        renderPage();
+        await waitFor(() => screen.getByRole('button', { name: /Import from System/i }));
+        await user.click(screen.getByRole('button', { name: /Import from System/i }));
+        // Wait for the modal heading to appear
+        await waitFor(() => screen.getByText('Import Students'));
+        // The modal's student list — scope search to the list element
+        const list = await waitFor(() => screen.getByRole('list'));
+        const { queryByText, getByText } = within(list);
+        expect(queryByText('Alice Adams')).not.toBeInTheDocument();
+        expect(queryByText('Bob Brown')).not.toBeInTheDocument();
+        expect(getByText('Charlie Clark')).toBeInTheDocument();
+    });
+
+    it('import modal filters students by search input', async () => {
+        const user = userEvent.setup();
+        renderPage();
+        await waitFor(() => screen.getByRole('button', { name: /Import from System/i }));
+        await user.click(screen.getByRole('button', { name: /Import from System/i }));
+        await waitFor(() => screen.getByPlaceholderText(/Search by name/i));
+        await user.type(screen.getByPlaceholderText(/Search by name/i), 'xxx');
+        await waitFor(() => {
+            expect(screen.queryByText('Charlie Clark')).not.toBeInTheDocument();
+        });
+    });
+
+    it('submitting Add Student form calls addDoc twice (student + eventStudents)', async () => {
+        const { addDoc } = await import('firebase/firestore');
+        const user = userEvent.setup();
+        renderPage();
+        await waitFor(() => screen.getByRole('button', { name: /\+ Add Student/i }));
+        await user.click(screen.getByRole('button', { name: /\+ Add Student/i }));
+
+        await waitFor(() => screen.getByText('Add New Student'));
+        const textboxes = screen.getAllByRole('textbox');
+        await user.type(textboxes[0], 'Dan');
+        await user.type(textboxes[1], 'Smith');
+
+        // The modal's submit button is inside a form — use type="submit"
+        const submitBtn = screen.getByRole('button', { name: /^Add Student$/i });
+        await user.click(submitBtn);
+
+        await waitFor(() => {
+            expect(addDoc).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/frontend/src/pages/EventsPage.jsx
+++ b/frontend/src/pages/EventsPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { db } from '../utils/firebase';
 import { collection, onSnapshot, doc, updateDoc, addDoc } from 'firebase/firestore';
 import { useEvent } from '../contexts/EventContext';
@@ -152,7 +153,7 @@ export default function EventsPage() {
                                     className="text-xs font-bold"
                                     onClick={() => handleEditConfig(event)}
                                 >
-                                    View Detail
+                                    Edit Config
                                 </Button>
 
                                 {!isActive ? (
@@ -170,13 +171,19 @@ export default function EventsPage() {
                                 )}
                             </div>
 
-                            <div className="flex items-center justify-center border-t pt-4">
+                            <div className="flex items-center justify-between border-t pt-4">
                                 <button
                                     onClick={() => handleEditConfig(event)}
                                     className="text-[10px] font-black text-gray-400 hover:text-primary-600 transition-colors uppercase tracking-widest"
                                 >
                                     Edit Configuration
                                 </button>
+                                <Link
+                                    to={`/admin/settings/events/${event.id}/students`}
+                                    className="text-[10px] font-black text-primary-500 hover:text-primary-700 transition-colors uppercase tracking-widest"
+                                >
+                                    View Students →
+                                </Link>
                             </div>
                         </div>
                     );

--- a/frontend/src/pages/StudentDetailPage.jsx
+++ b/frontend/src/pages/StudentDetailPage.jsx
@@ -5,11 +5,12 @@ import { formatTime, formatHours } from '../utils/hourCalculations';
 import { generateFilledPdf, openPdfForPrinting } from '../utils/pdfTemplateUtils';
 
 import { db, functions, storage } from '../utils/firebase';
-import { doc, getDoc, collection, query, where, onSnapshot, orderBy, Timestamp, updateDoc } from 'firebase/firestore';
+import { doc, getDoc, collection, query, where, onSnapshot, orderBy, Timestamp, updateDoc, getDocs } from 'firebase/firestore';
 import { ref, getDownloadURL } from 'firebase/storage';
 import { httpsCallable } from 'firebase/functions';
 
 import { useEvent } from '../contexts/EventContext';
+import { Link } from 'react-router-dom';
 import { buildEditChangeDescription } from '../utils/changeDescriptions';
 import Spinner from '../components/common/Spinner';
 import Button from '../components/common/Button';
@@ -25,6 +26,7 @@ export default function StudentDetailPage() {
     const [student, setStudent] = useState(null);
     const [entries, setEntries] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [eventHistory, setEventHistory] = useState([]); // [{eventId, eventName, totalHours}]
     const [printMode, setPrintMode] = useState(null);
     const [notesModal, setNotesModal] = useState({ isOpen: false, entry: null });
 
@@ -90,6 +92,38 @@ export default function StudentDetailPage() {
             }
         }
         if (studentId) fetchStudent();
+    }, [studentId]);
+
+    // Load cross-event history for this student
+    useEffect(() => {
+        if (!studentId) return;
+
+        async function loadEventHistory() {
+            const [entriesSnap, eventsSnap] = await Promise.all([
+                getDocs(query(collection(db, 'timeEntries'), where('studentId', '==', studentId))),
+                getDocs(collection(db, 'events')),
+            ]);
+
+            const eventsMap = {};
+            eventsSnap.docs.forEach(d => { eventsMap[d.id] = d.data().name || d.id; });
+
+            const hoursByEvent = {};
+            entriesSnap.docs.forEach(d => {
+                const data = d.data();
+                if (data.isVoided || !data.checkOutTime) return;
+                const diff = (data.checkOutTime.seconds - data.checkInTime.seconds) / 3600;
+                const rounded = Math.round(diff * 4) / 4;
+                hoursByEvent[data.eventId] = (hoursByEvent[data.eventId] || 0) + rounded;
+            });
+
+            setEventHistory(
+                Object.entries(hoursByEvent)
+                    .map(([eventId, totalHours]) => ({ eventId, eventName: eventsMap[eventId] || eventId, totalHours }))
+                    .sort((a, b) => a.eventName.localeCompare(b.eventName))
+            );
+        }
+
+        loadEventHistory();
     }, [studentId]);
 
     // Fetch PDF templates and default template setting
@@ -649,7 +683,8 @@ export default function StudentDetailPage() {
                 </div>
 
                 <div className="grid grid-cols-1 lg:grid-cols-4 gap-8 no-print">
-                    <div className="lg:col-span-1 bg-white rounded-2xl shadow-sm border p-6 h-fit">
+                    <div className="lg:col-span-1 space-y-4">
+                        <div className="bg-white rounded-2xl shadow-sm border p-6">
                         <h3 className="text-xs font-black text-gray-400 uppercase tracking-widest mb-4">Summary</h3>
                         <div className="space-y-4">
                             {activityLog.map(act => (
@@ -668,6 +703,28 @@ export default function StudentDetailPage() {
                                 )}
                             </div>
                         </div>
+                        </div>
+
+                        {eventHistory.length > 0 && (
+                            <div className="bg-white rounded-2xl shadow-sm border p-6">
+                                <h3 className="text-xs font-black text-gray-400 uppercase tracking-widest mb-4">Event History</h3>
+                                <div className="space-y-2">
+                                    {eventHistory.map(ev => (
+                                        <div key={ev.eventId} className="flex justify-between items-center">
+                                            <Link
+                                                to={`/admin/settings/events/${ev.eventId}/students`}
+                                                className="text-sm font-semibold text-primary-700 hover:underline truncate"
+                                            >
+                                                {ev.eventName}
+                                            </Link>
+                                            <span className="text-sm font-black text-gray-900 bg-gray-100 px-3 py-1 rounded-lg ml-2 shrink-0">
+                                                {ev.totalHours.toFixed(2)} hrs
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                     </div>
 
                     <div className="lg:col-span-3">

--- a/frontend/src/pages/StudentDetailPage.manualEntry.test.jsx
+++ b/frontend/src/pages/StudentDetailPage.manualEntry.test.jsx
@@ -37,6 +37,7 @@ vi.mock('firebase/firestore', () => ({
     query: vi.fn((ref) => ref),
     where: vi.fn(() => ({})),
     orderBy: vi.fn(() => ({})),
+    getDocs: vi.fn(() => Promise.resolve({ docs: [] })),
     Timestamp: {
         fromDate: (date) => ({ toDate: () => date, seconds: Math.floor(date.getTime() / 1000) })
     },

--- a/frontend/src/pages/StudentDetailPage.test.jsx
+++ b/frontend/src/pages/StudentDetailPage.test.jsx
@@ -67,6 +67,7 @@ vi.mock('firebase/firestore', () => ({
   query: vi.fn((ref) => ref),
   where: vi.fn(() => ({})),
   orderBy: vi.fn(() => ({})),
+  getDocs: vi.fn(() => Promise.resolve({ docs: [] })),
   Timestamp: {
     fromDate: (date) => ({ toDate: () => date, seconds: Math.floor(date.getTime() / 1000) })
   },


### PR DESCRIPTION
## Summary
- Moves Students from the Operations nav to the Settings section (now at `/admin/settings/students`) for global student management
- Adds event history to StudentDetailPage showing every event a student has participated in with hours, with links to each event's student roster
- Creates a new EventStudentsPage showing only students checked in or explicitly added to an event, with "Add Student" and "Import from System" tools
- Adds "View Students →" link on event cards in the Events settings page
- Introduces an `eventStudents` Firestore collection for explicit event-student associations

## Closes
Fixes #52

## Test plan
- [x] All 593 unit tests pass
- [ ] Navigate to Settings > Students — all students in system should appear
- [ ] Open a student detail — Event History section shows events participated in
- [ ] Navigate to Settings > Events — each card has "View Students →" link
- [ ] Click "View Students →" — only students checked in or added appear
- [ ] "Import from System" button — shows only students not yet in the event
- [ ] Selecting and confirming import adds students to the event roster
- [ ] "+ Add Student" creates a new student and automatically links them to the event

🤖 Generated with [Claude Code](https://claude.com/claude-code)