### PR TITLE
fix: restore Students to Operations nav (per-event view)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -181,8 +181,7 @@ function App() {
               <Route index element={<AdminDashboardPage />} />
               <Route path="daily-review" element={<DailyReviewPage />} />
               <Route path="forms" element={<FormGenerationPage />} />
-              <Route path="students" element={<Navigate to="/admin/settings/students" replace />} />
-              <Route path="students/:studentId" element={<Navigate to="/admin/settings/students/:studentId" replace />} />
+              <Route path="students" element={<EventStudentsPage />} />
               <Route path="events" element={<Navigate to="/admin/settings/events" replace />} />
               <Route path="events/new" element={<Navigate to="/admin/settings/events/new" replace />} />
               <Route path="users" element={<Navigate to="/admin/settings/users" replace />} />

--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -40,6 +40,7 @@ export default function Header({
 
   const operationsNav = [
     { path: '/admin', label: 'Dashboard', exact: true },
+    { path: '/admin/students', label: 'Students' },
     { path: '/admin/daily-review', label: 'Daily Review' },
   ];
 

--- a/frontend/src/components/common/Header.test.jsx
+++ b/frontend/src/components/common/Header.test.jsx
@@ -60,11 +60,10 @@ describe('Header', () => {
     renderWithRouter(<Header />);
 
     expect(screen.getAllByRole('link', { name: 'Dashboard' }).some(link => link.getAttribute('href') === '/admin')).toBe(true);
+    expect(screen.getAllByRole('link', { name: 'Students' }).some(link => link.getAttribute('href') === '/admin/students')).toBe(true);
     expect(screen.getAllByRole('link', { name: 'Daily Review' }).some(link => link.getAttribute('href') === '/admin/daily-review')).toBe(true);
     expect(screen.getByRole('link', { name: /settings/i })).toHaveAttribute('href', '/admin/settings');
     expect(screen.queryByRole('link', { name: 'Events' })).not.toBeInTheDocument();
-    // Students is now under Settings, not in the Operations nav
-    expect(screen.queryByRole('link', { name: 'Students' })).not.toBeInTheDocument();
   });
 
   it('highlights settings when a settings route is active', () => {
@@ -74,10 +73,10 @@ describe('Header', () => {
   });
 
   it('highlights active operational links', () => {
-    renderWithRouter(<Header />, { route: '/admin/daily-review' });
+    renderWithRouter(<Header />, { route: '/admin/students' });
 
-    const dailyReviewLinks = screen.getAllByRole('link', { name: 'Daily Review' });
-    expect(dailyReviewLinks.some(link => link.classList.contains('bg-primary-50'))).toBe(true);
+    const studentsLinks = screen.getAllByRole('link', { name: 'Students' });
+    expect(studentsLinks.some(link => link.classList.contains('bg-primary-50'))).toBe(true);
   });
 
   it('switches the active event from the context switcher', async () => {
@@ -101,6 +100,7 @@ describe('Header', () => {
     renderWithRouter(<Header showNavTabs={false} />);
 
     expect(screen.queryByRole('link', { name: 'Daily Review' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Students' })).not.toBeInTheDocument();
   });
 
   it('hides event indicator text when showEventIndicator is false', () => {
@@ -132,7 +132,7 @@ describe('Header', () => {
     await user.click(screen.getByRole('button', { name: /open menu/i }));
     expect(screen.getByRole('button', { name: /close menu/i })).toHaveAttribute('aria-expanded', 'true');
 
-    await user.click(screen.getAllByRole('link', { name: 'Daily Review' })[0]);
+    await user.click(screen.getAllByRole('link', { name: 'Students' })[0]);
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /open menu/i })).toBeInTheDocument();

--- a/frontend/src/pages/EventStudentsPage.jsx
+++ b/frontend/src/pages/EventStudentsPage.jsx
@@ -11,12 +11,18 @@ import {
     serverTimestamp,
 } from 'firebase/firestore';
 import { useAuth } from '../contexts/AuthContext';
+import { useEvent } from '../contexts/EventContext';
 import Button from '../components/common/Button';
 import Spinner from '../components/common/Spinner';
 
 export default function EventStudentsPage() {
-    const { eventId } = useParams();
+    const { eventId: paramEventId } = useParams();
+    const { currentEvent } = useEvent();
     const { user } = useAuth();
+
+    // Use URL param when navigating from event card; fall back to the selected event in Operations
+    const eventId = paramEventId || currentEvent?.id;
+    const isOperationsView = !paramEventId;
 
     const [event, setEvent] = useState(null);
     const [allStudents, setAllStudents] = useState([]);
@@ -33,15 +39,19 @@ export default function EventStudentsPage() {
     const [importSelected, setImportSelected] = useState(new Set());
     const [importSaving, setImportSaving] = useState(false);
 
-    // Load event
+    // Load event — use context if available (Operations nav), otherwise fetch from Firestore
     useEffect(() => {
+        if (isOperationsView && currentEvent) {
+            setEvent(currentEvent);
+            return;
+        }
         if (!eventId) return;
         const unsub = onSnapshot(collection(db, 'events'), snap => {
             const found = snap.docs.find(d => d.id === eventId);
             if (found) setEvent({ id: found.id, ...found.data() });
         });
         return () => unsub();
-    }, [eventId]);
+    }, [eventId, isOperationsView, currentEvent]);
 
     // Load all students
     useEffect(() => {
@@ -163,13 +173,15 @@ export default function EventStudentsPage() {
             {/* Page header */}
             <div className="mb-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                 <div>
-                    <div className="flex items-center gap-2 text-xs text-gray-400 font-bold uppercase tracking-widest mb-1">
-                        <Link to="/admin/settings/events" className="hover:text-primary-600">Events</Link>
-                        <span>/</span>
-                        <span className="text-gray-600">{event?.name || eventId}</span>
-                        <span>/</span>
-                        <span className="text-gray-600">Students</span>
-                    </div>
+                    {!isOperationsView && (
+                        <div className="flex items-center gap-2 text-xs text-gray-400 font-bold uppercase tracking-widest mb-1">
+                            <Link to="/admin/settings/events" className="hover:text-primary-600">Events</Link>
+                            <span>/</span>
+                            <span className="text-gray-600">{event?.name || eventId}</span>
+                            <span>/</span>
+                            <span className="text-gray-600">Students</span>
+                        </div>
+                    )}
                     <h2 className="text-2xl font-black text-gray-900 tracking-tight">
                         {event?.name || 'Event'} — Students
                     </h2>

--- a/frontend/src/pages/EventStudentsPage.test.jsx
+++ b/frontend/src/pages/EventStudentsPage.test.jsx
@@ -55,6 +55,10 @@ vi.mock('../contexts/AuthContext', () => ({
     useAuth: () => ({ user: { uid: 'admin123' } }),
 }));
 
+vi.mock('../contexts/EventContext', () => ({
+    useEvent: () => ({ currentEvent: { id: 'event123', name: 'VBS 2026' } }),
+}));
+
 const renderPage = () => render(
     <MemoryRouter initialEntries={['/admin/settings/events/event123/students']}>
         <Routes>


### PR DESCRIPTION
## Summary
- Restores **Students** to the Operations sidebar nav, pointing to `/admin/students`
- The Operations Students view now shows only students for the **currently selected event** (uses `EventContext`) — not the global all-students list
- Settings > Students remains the global roster of all students in the system
- `EventStudentsPage` handles both contexts: Operations nav uses `currentEvent` from context; event card "View Students →" link uses the URL param

## Notes
This fix was pushed after PR #54 was merged. No new files — only updates to `EventStudentsPage.jsx`, `App.jsx`, `Header.jsx`, and their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)