### PR TITLE
fix: add Firestore rule for eventStudents collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -65,5 +65,10 @@ service cloud.firestore {
     match /settings/{settingId} {
       allow read, write: if isAdmin();
     }
+
+    // Event-student associations: Admin only
+    match /eventStudents/{docId} {
+      allow read, write: if isAdmin();
+    }
   }
 }


### PR DESCRIPTION
## Summary
The `eventStudents` collection introduced in PR #54 was missing a Firestore security rule, causing all reads and writes to be silently denied. This prevented students from being added to an event unless they already had a time entry.

## Fix
Added an admin-only read/write rule for `eventStudents`.

Rules have already been deployed to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)