### PR TITLE
Display and log scanner user identity

### DIFF
--- a/frontend/src/components/Scanner/Scanner.test.jsx
+++ b/frontend/src/components/Scanner/Scanner.test.jsx
@@ -7,6 +7,7 @@ import Scanner from './index';
 // Mock useQRScanner hook
 const mockStartScanning = vi.fn().mockResolvedValue(undefined);
 const mockStopScanning = vi.fn().mockResolvedValue(undefined);
+const mockScanCallable = vi.hoisted(() => vi.fn());
 
 vi.mock('../../hooks/useQRScanner', () => ({
   __esModule: true,
@@ -79,9 +80,7 @@ vi.mock('firebase/firestore', () => {
 });
 
 vi.mock('firebase/functions', () => ({
-  httpsCallable: vi.fn(() => vi.fn().mockResolvedValue({
-    data: { success: true, studentName: 'Test Student' },
-  })),
+  httpsCallable: vi.fn(() => mockScanCallable),
 }));
 
 // Mock parseQRData
@@ -105,6 +104,7 @@ vi.mock('../../hooks/useOfflineSync', () => ({
 // Mock AuthContext
 vi.mock('../../contexts/AuthContext', () => ({
   useAuth: () => ({
+    user: { uid: 'admin123', email: 'test@test.com', displayName: 'Auth Test User' },
     userProfile: { name: 'Test User', email: 'test@test.com', role: 'admin' },
     signOut: vi.fn(),
     canAccessAdmin: () => true,
@@ -129,6 +129,9 @@ describe('Scanner', () => {
     vi.clearAllMocks();
     vi.useFakeTimers({ shouldAdvanceTime: true });
     mockUseQRScannerOptions = null;
+    mockScanCallable.mockResolvedValue({
+      data: { success: true, studentName: 'Test Student' },
+    });
   });
 
   afterEach(() => {
@@ -245,6 +248,58 @@ describe('Scanner', () => {
         expect(screen.getByText('VBS 2026')).toBeInTheDocument();
         expect(screen.getByText('General')).toBeInTheDocument();
       });
+    });
+
+    it('should display the signed-in scanner name', async () => {
+      renderScanner('/scan/event1/general/checkin');
+
+      await waitFor(() => {
+        expect(screen.getByText('Signed in as Test User')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('scan logging identity', () => {
+    it('should send signed-in scanner identity on check-in', async () => {
+      renderScanner('/scan/event1/general/checkin');
+
+      await waitFor(() => {
+        expect(mockUseQRScannerOptions).not.toBeNull();
+      });
+
+      await mockUseQRScannerOptions.onSuccess('valid-qr');
+
+      expect(mockScanCallable).toHaveBeenCalledWith(
+        expect.objectContaining({
+          studentId: 'student1',
+          eventId: 'event1',
+          activityId: 'general',
+          scannedBy: 'admin123',
+          scannedByName: 'Test User',
+          method: 'av_scan',
+        })
+      );
+    });
+
+    it('should send av_scan method and signed-in scanner identity on check-out', async () => {
+      renderScanner('/scan/event1/general/checkout');
+
+      await waitFor(() => {
+        expect(mockUseQRScannerOptions).not.toBeNull();
+      });
+
+      await mockUseQRScannerOptions.onSuccess('valid-qr');
+
+      expect(mockScanCallable).toHaveBeenCalledWith(
+        expect.objectContaining({
+          studentId: 'student1',
+          eventId: 'event1',
+          activityId: 'general',
+          scannedBy: 'admin123',
+          scannedByName: 'Test User',
+          method: 'av_scan',
+        })
+      );
     });
   });
 });

--- a/frontend/src/components/Scanner/index.jsx
+++ b/frontend/src/components/Scanner/index.jsx
@@ -8,9 +8,12 @@ import ScannerHeader from '../common/ScannerHeader';
 import Spinner from '../common/Spinner';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { parseQRData } from '../../utils/qrCodeGenerator';
+import { useAuth } from '../../contexts/AuthContext';
+
 export default function Scanner() {
   const { eventId: urlEventId, activityId: urlActivityId, action: urlAction } = useParams();
   const navigate = useNavigate();
+  const { user, userProfile } = useAuth();
 
   const [localEvent, setLocalEvent] = useState(null);
   const [allEvents, setAllEvents] = useState([]);
@@ -19,6 +22,8 @@ export default function Scanner() {
   const isStarting = useRef(false);
   const isProcessing = useRef(false);
   const pauseAfterValidScan = 2000;
+  const scannerId = user?.uid || userProfile?.id || 'av_scan';
+  const scannerName = userProfile?.name || user?.displayName || user?.email || '';
 
   useEffect(() => {
     async function fetchData() {
@@ -87,7 +92,9 @@ export default function Scanner() {
           studentId,
           eventId: urlEventId,
           activityId: urlActivityId,
-          scannedBy: 'av_scan'
+          scannedBy: scannerId,
+          scannedByName: scannerName,
+          method: 'av_scan'
         });
 
         if (result.data.success) {

--- a/frontend/src/components/common/ScannerHeader.jsx
+++ b/frontend/src/components/common/ScannerHeader.jsx
@@ -10,8 +10,9 @@ import { useAuth } from '../../contexts/AuthContext';
  * to provide a streamlined experience during check-in/check-out operations.
  */
 export default function ScannerHeader() {
-  const { signOut, canAccessAdmin } = useAuth();
+  const { user, userProfile, signOut, canAccessAdmin } = useAuth();
   const navigate = useNavigate();
+  const displayName = userProfile?.name || user?.displayName || user?.email || 'Signed-in user';
 
   const handleSignOut = async () => {
     await signOut();
@@ -33,6 +34,7 @@ export default function ScannerHeader() {
         <div>
           <p className="text-[10px] font-black uppercase tracking-widest text-primary-600">Scan Mode</p>
           <h1 className="text-sm font-black text-gray-950">VBS Volunteer Tracker</h1>
+          <p className="mt-0.5 text-xs font-medium text-gray-500">Signed in as {displayName}</p>
         </div>
 
         <button

--- a/frontend/src/components/common/ScannerHeader.test.jsx
+++ b/frontend/src/components/common/ScannerHeader.test.jsx
@@ -18,6 +18,8 @@ let mockCanAccessAdmin = vi.fn(() => true);
 
 vi.mock('../../contexts/AuthContext', () => ({
   useAuth: () => ({
+    user: { email: 'fallback@test.com', displayName: 'Fallback User' },
+    userProfile: { name: 'Scanner Person', email: 'scanner@test.com', role: 'adult_volunteer' },
     signOut: mockSignOut,
     canAccessAdmin: mockCanAccessAdmin,
   }),
@@ -42,6 +44,7 @@ describe('ScannerHeader', () => {
 
     expect(screen.getByText('Scan Mode')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'VBS Volunteer Tracker' })).toBeInTheDocument();
+    expect(screen.getByText('Signed in as Scanner Person')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Exit Scan Mode' })).toBeInTheDocument();
   });
 

--- a/functions/src/checkIn.js
+++ b/functions/src/checkIn.js
@@ -9,10 +9,11 @@ import { getFirestore, Timestamp } from 'firebase-admin/firestore';
  * @param {string} request.data.studentId - Student ID
  * @param {string} request.data.eventId - Event ID
  * @param {string} request.data.activityId - Activity ID
- * @param {string} request.data.scannedBy - Who scanned (e.g., 'av_scan')
+ * @param {string} request.data.scannedBy - Fallback scanner user ID
+ * @param {string} request.data.scannedByName - Fallback scanner display name
  */
 export const checkIn = onCall({ cors: true }, async (request) => {
-  const { studentId, eventId, activityId, scannedBy } = request.data;
+  const { studentId, eventId, activityId, scannedBy, scannedByName } = request.data;
 
   // Validate required fields
   if (!studentId || !eventId || !activityId) {
@@ -59,6 +60,8 @@ export const checkIn = onCall({ cors: true }, async (request) => {
     // Create time entry
     const checkInTime = Timestamp.now();
     const flags = getFlagsForCheckIn(checkInTime.toDate(), event.typicalStartTime || '09:00');
+    const scannerId = request.auth?.uid || scannedBy || 'av_scan';
+    const scannerName = request.auth?.token?.name || scannedByName || null;
 
     const entry = {
       studentId,
@@ -66,7 +69,8 @@ export const checkIn = onCall({ cors: true }, async (request) => {
       activityId,
       date: today,
       checkInTime,
-      checkInBy: scannedBy || 'av_scan',
+      checkInBy: scannerId,
+      checkInByName: scannerName,
       checkInMethod: 'av_scan',
       checkOutTime: null,
       checkOutBy: null,

--- a/functions/src/checkOut.js
+++ b/functions/src/checkOut.js
@@ -9,9 +9,11 @@ import { getFirestore, Timestamp } from 'firebase-admin/firestore';
  * @param {string} request.data.studentId - Student ID
  * @param {string} request.data.eventId - Event ID
  * @param {string} request.data.method - Check-out method: 'self_scan' | 'av_scan'
+ * @param {string} request.data.scannedBy - Fallback scanner user ID
+ * @param {string} request.data.scannedByName - Fallback scanner display name
  */
 export const checkOut = onCall({ cors: true }, async (request) => {
-  const { studentId, eventId, activityId, method } = request.data;
+  const { studentId, eventId, activityId, method, scannedBy, scannedByName } = request.data;
 
   // Validate required fields
   if (!studentId || !eventId || !activityId) {
@@ -63,12 +65,20 @@ export const checkOut = onCall({ cors: true }, async (request) => {
     // Combine existing flags with checkout flags
     const checkOutFlags = getFlagsForCheckOut(checkOutTime.toDate(), event.typicalEndTime || '15:00');
     const allFlags = [...(entry.flags || []), ...checkOutFlags];
+    const checkOutMethod = method || 'self_scan';
+    const scannerId = checkOutMethod === 'self_scan'
+      ? 'student_self'
+      : (request.auth?.uid || scannedBy || 'av');
+    const scannerName = checkOutMethod === 'self_scan'
+      ? null
+      : (request.auth?.token?.name || scannedByName || null);
 
     // Update entry
     await entryDoc.ref.update({
       checkOutTime,
-      checkOutBy: method === 'self_scan' ? 'student_self' : (request.auth?.uid || 'av'),
-      checkOutMethod: method || 'self_scan',
+      checkOutBy: scannerId,
+      checkOutByName: scannerName,
+      checkOutMethod,
       hoursWorked: rounded,
       rawMinutes: minutes,
       flags: allFlags,

--- a/functions/test/checkIn.test.js
+++ b/functions/test/checkIn.test.js
@@ -61,7 +61,7 @@ jest.unstable_mockModule('firebase-admin/firestore', () => ({
 }));
 
 jest.unstable_mockModule('firebase-functions/v2/https', () => ({
-  onCall: (handler) => handler,
+  onCall: (...args) => args[args.length - 1],
   HttpsError: class HttpsError extends Error {
     constructor(code, message) {
       super(message);
@@ -179,6 +179,28 @@ describe('checkIn Cloud Function', () => {
 
       const addCall = mockAdd.mock.calls[0][0];
       expect(addCall.checkInMethod).toBe('av_scan');
+    });
+
+    it('should log the authenticated scanner user on the time entry', async () => {
+      const request = {
+        data: {
+          studentId: 'student123',
+          eventId: 'event456',
+          activityId: 'activity1',
+          scannedBy: 'client_fallback',
+          scannedByName: 'Client Fallback',
+        },
+        auth: {
+          uid: 'auth_scanner_123',
+          token: { name: 'Authenticated Scanner' },
+        },
+      };
+
+      await checkIn(request);
+
+      const addCall = mockAdd.mock.calls[0][0];
+      expect(addCall.checkInBy).toBe('auth_scanner_123');
+      expect(addCall.checkInByName).toBe('Authenticated Scanner');
     });
 
     it('should set correct initial status for flagged entries', async () => {

--- a/functions/test/checkOut.test.js
+++ b/functions/test/checkOut.test.js
@@ -72,7 +72,7 @@ jest.unstable_mockModule('firebase-admin/firestore', () => ({
 }));
 
 jest.unstable_mockModule('firebase-functions/v2/https', () => ({
-  onCall: (handler) => handler,
+  onCall: (...args) => args[args.length - 1],
   HttpsError: class HttpsError extends Error {
     constructor(code, message) {
       super(message);
@@ -191,8 +191,10 @@ describe('checkOut Cloud Function', () => {
           eventId: 'event456',
           activityId: 'activity1',
           method: 'av_scan',
+          scannedBy: 'client_fallback',
+          scannedByName: 'Client Fallback',
         },
-        auth: { uid: 'av_user_123' },
+        auth: { uid: 'av_user_123', token: { name: 'Adult Volunteer' } },
       };
 
       await checkOut(request);
@@ -202,7 +204,33 @@ describe('checkOut Cloud Function', () => {
           checkOutTime: expect.anything(),
           hoursWorked: 6,
           rawMinutes: 360,
+          checkOutBy: 'av_user_123',
+          checkOutByName: 'Adult Volunteer',
           checkOutMethod: 'av_scan',
+        })
+      );
+    });
+
+    it('should preserve student_self logging for self-scan check-out', async () => {
+      const request = {
+        data: {
+          studentId: 'student123',
+          eventId: 'event456',
+          activityId: 'activity1',
+          method: 'self_scan',
+          scannedBy: 'av_user_123',
+          scannedByName: 'Adult Volunteer',
+        },
+        auth: { uid: 'av_user_123', token: { name: 'Adult Volunteer' } },
+      };
+
+      await checkOut(request);
+
+      expect(mockEntryDoc.ref.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          checkOutBy: 'student_self',
+          checkOutByName: null,
+          checkOutMethod: 'self_scan',
         })
       );
     });


### PR DESCRIPTION
## Summary
- show the signed-in user name in scan mode
- send the signed-in scanner identity with check-in and check-out scans
- store authenticated scanner UID/name on time entries while preserving self-scan behavior
- fix function test onCall mocks to support options-based callables

Closes #60

## Tests
- npm test -- Scanner.test.jsx ScannerHeader.test.jsx
- npm test -- checkIn.test.js checkOut.test.js