### PR TITLE
feat: add search to Event Students page (#65)

### DIFF
--- a/frontend/src/pages/EventStudentsPage.jsx
+++ b/frontend/src/pages/EventStudentsPage.jsx
@@ -30,6 +30,8 @@ export default function EventStudentsPage() {
     const [checkedInStudentIds, setCheckedInStudentIds] = useState(new Set());
     const [loading, setLoading] = useState(true);
 
+    const [searchTerm, setSearchTerm] = useState('');
+
     const [addStudentModal, setAddStudentModal] = useState(false);
     const [addForm, setAddForm] = useState({ firstName: '', lastName: '', schoolName: '', gradeLevel: '', gradYear: '' });
     const [addingSaving, setAddingSaving] = useState(false);
@@ -92,6 +94,13 @@ export default function EventStudentsPage() {
             .filter(s => eventStudentIds.has(s.id) || checkedInStudentIds.has(s.id))
             .sort((a, b) => a.lastName.localeCompare(b.lastName));
     }, [allStudents, eventStudentIds, checkedInStudentIds]);
+
+    const filteredStudents = useMemo(() => {
+        if (!searchTerm.trim()) return eventStudents;
+        return eventStudents.filter(s =>
+            `${s.firstName} ${s.lastName}`.toLowerCase().includes(searchTerm.toLowerCase())
+        );
+    }, [eventStudents, searchTerm]);
 
     // Students not yet associated with this event (for import modal)
     const importableStudents = useMemo(() => {
@@ -186,10 +195,21 @@ export default function EventStudentsPage() {
                         {event?.name || 'Event'} — Students
                     </h2>
                     <p className="text-gray-500 text-sm font-medium mt-1">
-                        {eventStudents.length} student{eventStudents.length !== 1 ? 's' : ''} associated with this event
+                        {searchTerm.trim()
+                            ? `${filteredStudents.length} of ${eventStudents.length} student${eventStudents.length !== 1 ? 's' : ''}`
+                            : `${eventStudents.length} student${eventStudents.length !== 1 ? 's' : ''}`
+                        } associated with this event
                     </p>
                 </div>
-                <div className="flex gap-2 shrink-0">
+                <div className="flex flex-wrap gap-2 shrink-0 items-center">
+                    <input
+                        type="search"
+                        placeholder="Search students…"
+                        value={searchTerm}
+                        onChange={e => setSearchTerm(e.target.value)}
+                        className="border border-gray-200 rounded-xl px-4 py-2 text-sm w-52 outline-none focus:ring-2 focus:ring-primary-500 shadow-sm"
+                        aria-label="Search students"
+                    />
                     {allStudents.length > eventStudents.length && (
                         <Button
                             variant="secondary"
@@ -224,7 +244,14 @@ export default function EventStudentsPage() {
                             </tr>
                         </thead>
                         <tbody className="divide-y divide-gray-100">
-                            {eventStudents.map(s => (
+                            {filteredStudents.length === 0 ? (
+                                <tr>
+                                    <td colSpan={6} className="px-6 py-12 text-center text-gray-400">
+                                        <p className="font-bold">No students match your search</p>
+                                        <p className="text-sm mt-1">Try a different name.</p>
+                                    </td>
+                                </tr>
+                            ) : filteredStudents.map(s => (
                                 <tr key={s.id} className="hover:bg-gray-50 transition-colors">
                                     <td className="px-6 py-4 font-bold text-gray-900">
                                         {s.firstName} {s.lastName}

--- a/frontend/src/pages/EventStudentsPage.test.jsx
+++ b/frontend/src/pages/EventStudentsPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import EventStudentsPage from './EventStudentsPage';
@@ -164,6 +164,45 @@ describe('EventStudentsPage', () => {
         await waitFor(() => {
             expect(screen.queryByText('Charlie Clark')).not.toBeInTheDocument();
         });
+    });
+
+    it('renders a search input', async () => {
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByRole('searchbox', { name: /Search students/i })).toBeInTheDocument();
+        });
+    });
+
+    it('filters students by search term', async () => {
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+
+        const searchInput = screen.getByRole('searchbox', { name: /Search students/i });
+        act(() => { fireEvent.change(searchInput, { target: { value: 'Alice' } }); });
+
+        expect(screen.getByText('Alice Adams')).toBeInTheDocument();
+        expect(screen.queryByText('Bob Brown')).not.toBeInTheDocument();
+    });
+
+    it('shows no-results message when search matches nothing', async () => {
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+
+        const searchInput = screen.getByRole('searchbox', { name: /Search students/i });
+        act(() => { fireEvent.change(searchInput, { target: { value: 'zzz-no-match' } }); });
+
+        expect(screen.getByText(/No students match your search/i)).toBeInTheDocument();
+        expect(screen.queryByText('Alice Adams')).not.toBeInTheDocument();
+    });
+
+    it('shows filtered count in subtitle when searching', async () => {
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+
+        const searchInput = screen.getByRole('searchbox', { name: /Search students/i });
+        act(() => { fireEvent.change(searchInput, { target: { value: 'Alice' } }); });
+
+        expect(screen.getByText(/1 of 2 students/i)).toBeInTheDocument();
     });
 
     it('submitting Add Student form calls addDoc twice (student + eventStudents)', async () => {


### PR DESCRIPTION
## Summary

- Adds a real-time search input to the `/admin/students` (Event Students) page
- The student list is filtered as the user types, matching on first + last name
- The subtitle updates to show `N of M students` when a search is active
- When the search matches no students, an inline empty-state row is shown in the table
- The `Import from System` and `+ Add Student` buttons remain visible alongside the search input
- Print actions naturally honour the search: only `filteredStudents` is rendered, so any future print button would print the filtered list

## Test plan

- [x] 4 new unit tests added to `EventStudentsPage.test.jsx`:
  - `renders a search input` — confirms the search box is present
  - `filters students by search term` — confirms only matching students are shown
  - `shows no-results message when search matches nothing` — confirms empty state row
  - `shows filtered count in subtitle when searching` — confirms "N of M students" text
- [x] All 4 new tests pass in isolation (verified locally)
- [ ] Manual: navigate to `/admin/students`, type a name partial — list filters live
- [ ] Manual: clear the search — all students return, count shows total

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)