### PR TITLE
Add print actions to event students page

### DIFF
--- a/frontend/src/pages/EventStudentsPage.jsx
+++ b/frontend/src/pages/EventStudentsPage.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { printInNewWindow, createPrintDocument } from '../utils/printUtils';
 import { db } from '../utils/firebase';
 import {
     collection,
     onSnapshot,
     addDoc,
-    getDocs,
     query,
     where,
     serverTimestamp,
@@ -14,6 +15,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useEvent } from '../contexts/EventContext';
 import Button from '../components/common/Button';
 import Spinner from '../components/common/Spinner';
+import PrintableBadge from '../components/common/PrintableBadge';
 
 export default function EventStudentsPage() {
     const { eventId: paramEventId } = useParams();
@@ -26,9 +28,11 @@ export default function EventStudentsPage() {
 
     const [event, setEvent] = useState(null);
     const [allStudents, setAllStudents] = useState([]);
+    const [eventEntries, setEventEntries] = useState([]);
     const [eventStudentIds, setEventStudentIds] = useState(new Set());
     const [checkedInStudentIds, setCheckedInStudentIds] = useState(new Set());
     const [loading, setLoading] = useState(true);
+    const [printingReports, setPrintingReports] = useState(false);
 
     const [addStudentModal, setAddStudentModal] = useState(false);
     const [addForm, setAddForm] = useState({ firstName: '', lastName: '', schoolName: '', gradeLevel: '', gradYear: '' });
@@ -77,9 +81,11 @@ export default function EventStudentsPage() {
         const q = query(collection(db, 'timeEntries'), where('eventId', '==', eventId));
         const unsub = onSnapshot(q, snap => {
             const ids = new Set();
-            snap.docs.forEach(d => {
-                if (!d.data().isVoided) ids.add(d.data().studentId);
+            const entries = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+            entries.forEach(entry => {
+                if (!entry.isVoided) ids.add(entry.studentId);
             });
+            setEventEntries(entries);
             setCheckedInStudentIds(ids);
             setLoading(false);
         });
@@ -160,6 +166,159 @@ export default function EventStudentsPage() {
         });
     };
 
+    const roundTime = (hours) => Math.round(hours * 4) / 4;
+
+    const PRINT_STYLES = `
+        body { background: white; margin: 0; padding: 0; }
+        .badge-page { page-break-after: always; height: 100vh; width: 100vw; display: grid; grid-template-columns: repeat(2, 1fr); grid-template-rows: repeat(4, 1fr); gap: 0; padding: 0.25in; box-sizing: border-box; }
+        .badge-page:last-child { page-break-after: auto; }
+        .student-badge { border: 2px solid #000; padding: 0.15in; display: flex; flex-direction: column; align-items: center; justify-content: center; background: white; box-sizing: border-box; text-align: center; margin: 2px; }
+        .badge-name { font-size: 14pt; font-weight: bold; margin-bottom: 4px; color: #000; }
+        .badge-id { font-size: 9pt; color: #666; margin-bottom: 8px; }
+        .badge-qr { margin: 0 auto; }
+        .ocps-form-container { font-family: Arial, sans-serif; padding: 0.25in; color: black; line-height: 1.05; font-size: 8.5pt; page-break-after: always; height: 100vh; box-sizing: border-box; }
+        table { border-collapse: collapse; width: 100%; margin-bottom: 2px; }
+        th, td { border: 1px solid black; padding: 2px 6px; vertical-align: middle; }
+        .field-box { border-bottom: 1px solid black; display: inline-block; min-width: 120px; padding: 0 5px; font-weight: bold; }
+        .reflection-box { border: 1px solid black; height: 165px; width: 100%; margin-top: 2px; display: flex; flex-direction: column; }
+        .reflection-line { border-bottom: 1px solid #ddd; flex: 1; }
+        .ocps-logo { width: 40px; height: 40px; border: 1px solid black; display: flex; align-items: center; justify-content: center; font-weight: bold; font-size: 7pt; text-align: center; }
+    `;
+
+    const getStudentActivityLog = (studentId) => {
+        if (!event?.activities || eventEntries.length === 0) return [];
+
+        return event.activities.map(activity => {
+            const activityEntries = eventEntries.filter(entry =>
+                entry.studentId === studentId &&
+                entry.activityId === activity.id &&
+                entry.checkOutTime &&
+                !entry.isVoided
+            );
+            if (activityEntries.length === 0) return null;
+
+            const uniqueDates = [...new Set(activityEntries.map(entry =>
+                new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(entry.checkInTime.toDate())
+            ))].sort();
+
+            const totalHours = activityEntries.reduce((acc, entry) => {
+                const diff = (entry.checkOutTime.seconds - entry.checkInTime.seconds) / 3600;
+                return acc + roundTime(diff);
+            }, 0);
+
+            return {
+                name: activity.name,
+                dateDisplay: uniqueDates.map(date => {
+                    const parsed = new Date(date);
+                    return `${parsed.getMonth() + 1}/${parsed.getDate()}/${parsed.getFullYear().toString().slice(-2)}`;
+                }).join(', '),
+                totalHours: totalHours.toFixed(2)
+            };
+        }).filter(Boolean);
+    };
+
+    const handlePrintBadges = () => {
+        const pages = [];
+        for (let i = 0; i < eventStudents.length; i += 8) {
+            pages.push(eventStudents.slice(i, i + 8));
+        }
+
+        const body = pages.map((pageStudents, pageIndex) => (
+            `<div class="badge-page" data-page="${pageIndex + 1}">` +
+            pageStudents.map(student => renderToStaticMarkup(
+                <PrintableBadge student={student} eventId={eventId} />
+            )).join('') +
+            Array.from({ length: Math.max(0, 8 - pageStudents.length) })
+                .map(() => '<div class="student-badge" style="border:none"></div>')
+                .join('') +
+            '</div>'
+        )).join('');
+
+        const html = createPrintDocument({ title: `${event?.name || 'Event'} Badges`, styles: PRINT_STYLES, body });
+        printInNewWindow(html);
+    };
+
+    const buildStudentFormHtml = (student, activityLog, grandTotal) => {
+        const orgName = event?.organizationName || '';
+        const contactName = event?.contactName || '---';
+        const activityRows = activityLog.map(activity => `
+            <tr>
+                <td>${orgName} ${activity.name || ''}</td>
+                <td style="text-align:center">${activity.dateDisplay}</td>
+                <td>${contactName}</td>
+                <td></td>
+                <td style="font-weight:bold">${activity.totalHours}</td>
+            </tr>
+        `).join('');
+        const blankRows = Array.from({ length: Math.max(0, 10 - activityLog.length) })
+            .map(() => '<tr style="height:36px"><td></td><td></td><td></td><td></td><td></td></tr>')
+            .join('');
+
+        return `<div class="ocps-form-container">
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;border-bottom:2px solid black;padding-bottom:4px">
+                <div class="ocps-logo">OCPS</div>
+                <h1 style="font-size:13pt;font-weight:bold;text-align:center;flex:1">Community/Work Service Log and Reflection</h1>
+            </div>
+            <table style="margin-bottom:4px"><tbody>
+                <tr>
+                    <td style="width:33%;border:none">Student ID #: <span class="field-box" style="min-width:100px"></span></td>
+                    <td style="border:none">Student Name: <span class="field-box" style="min-width:220px">${student.firstName} ${student.lastName}</span></td>
+                </tr>
+                <tr>
+                    <td style="border:none">School Name: <span class="field-box" style="min-width:200px">${student.schoolName || ''}</span></td>
+                    <td style="border:none;text-align:right">Graduation Year: <span class="field-box" style="min-width:80px">${student.gradYear || '____'}</span></td>
+                </tr>
+            </tbody></table>
+            <p style="font-size:7.5pt;margin:2px 0">Social/Civic Issue/Professional Area Addressing with Service Activity Log (Optional):</p>
+            <div style="border-bottom:1px solid black;width:100%;margin-bottom:4px;height:16px"></div>
+            <p style="font-weight:bold;font-size:8pt;margin:2px 0">Description of Volunteer/Paid Work Activity:</p>
+            <div style="border-bottom:1px solid black;width:100%;margin-bottom:8px;height:16px"></div>
+            <table style="margin-bottom:8px;text-align:center"><thead>
+                <tr style="background:#f3f4f6;font-size:8pt">
+                    <th style="width:20%">Service Organization/Business</th>
+                    <th style="width:30%">Date(s) of Service Activity/Work</th>
+                    <th style="width:15%">Contact Name</th>
+                    <th style="width:20%">Signature of Contact</th>
+                    <th style="width:15%">Hours Completed</th>
+                </tr>
+            </thead><tbody>
+                ${activityRows}${blankRows}
+                <tr>
+                    <td colspan="4" style="text-align:right;font-weight:bold;text-transform:uppercase">Total:</td>
+                    <td style="font-weight:bold;background:#f9fafb">${grandTotal.toFixed(2)}</td>
+                </tr>
+            </tbody></table>
+            <div style="margin-top:4px">
+                <p style="font-weight:bold;font-size:7.5pt;margin:0">Reflection on Service Activity/Work (attach additional pages if necessary):</p>
+                <p style="font-size:6.5pt;font-style:italic;margin:2px 0">Attach a copy of your pay stub for work hours if applicable. Complete the reflection below...</p>
+                <div class="reflection-box">${Array.from({ length: 7 }).map(() => '<div class="reflection-line"></div>').join('')}</div>
+            </div>
+            <p style="font-size:7pt;margin-top:8px;font-weight:bold;line-height:1.3">By signing below, I certify that all information on this document is true and correct. I understand that if I am found to have given false testimony about these hours that the hours will be revoked and endanger my eligibility for the Bright Futures Scholarship.</p>
+            <div style="margin-top:12px;display:flex;justify-content:space-between">
+                <div style="font-size:8pt">Student Signature: _______________________ Date: ________</div>
+                <div style="font-size:8pt">Parent Signature: ________________________ Date: ________</div>
+            </div>
+            <p style="font-size:5.5pt;margin-top:4px;color:#9ca3af">Revised 8/2023</p>
+        </div>`;
+    };
+
+    const handlePrintReports = () => {
+        setPrintingReports(true);
+        try {
+            const formsHtml = eventStudents.map(student => {
+                const activityLog = getStudentActivityLog(student.id);
+                const totalCalc = activityLog.reduce((sum, activity) => sum + parseFloat(activity.totalHours), 0);
+                const grandTotal = totalCalc + parseFloat(student.overrideHours || 0);
+                return buildStudentFormHtml(student, activityLog, grandTotal);
+            }).join('');
+
+            const html = createPrintDocument({ title: `${event?.name || 'Event'} Service Logs`, styles: PRINT_STYLES, body: formsHtml });
+            printInNewWindow(html);
+        } finally {
+            setPrintingReports(false);
+        }
+    };
+
     if (loading) {
         return (
             <div className="min-h-screen bg-gray-50">
@@ -189,7 +348,18 @@ export default function EventStudentsPage() {
                         {eventStudents.length} student{eventStudents.length !== 1 ? 's' : ''} associated with this event
                     </p>
                 </div>
-                <div className="flex gap-2 shrink-0">
+                <div className="flex flex-wrap gap-2 shrink-0">
+                    <Button variant="secondary" onClick={handlePrintBadges} disabled={eventStudents.length === 0}>
+                        Print Badges
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        onClick={handlePrintReports}
+                        disabled={eventStudents.length === 0 || printingReports}
+                        loading={printingReports}
+                    >
+                        {printingReports ? 'Generating...' : 'Print Reports'}
+                    </Button>
                     {allStudents.length > eventStudents.length && (
                         <Button
                             variant="secondary"

--- a/frontend/src/pages/EventStudentsPage.test.jsx
+++ b/frontend/src/pages/EventStudentsPage.test.jsx
@@ -123,6 +123,14 @@ describe('EventStudentsPage', () => {
         });
     });
 
+    it('shows event-scoped print buttons', async () => {
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /Print Badges/i })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /Print Reports/i })).toBeInTheDocument();
+        });
+    });
+
     it('opens Add Student modal on button click', async () => {
         const user = userEvent.setup();
         renderPage();


### PR DESCRIPTION
## Summary
- Add Print Badges and Print Reports actions to the event-scoped students page
- Scope both print outputs to students associated with the event only
- Add regression coverage that the event-scoped print buttons render

Closes #63

## Verification
- npm run build
- ./node_modules/.bin/vitest run src/pages/EventStudentsPage.test.jsx -t "event-scoped print buttons" --reporter=verbose --testTimeout=5000

Note: the full EventStudentsPage test file hangs later in existing modal interaction tests; stopped that stuck run.