### PR TITLE
Add event student removal action

### DIFF
--- a/frontend/src/pages/EventStudentsPage.jsx
+++ b/frontend/src/pages/EventStudentsPage.jsx
@@ -7,6 +7,8 @@ import {
     collection,
     onSnapshot,
     addDoc,
+    deleteDoc,
+    doc,
     query,
     where,
     serverTimestamp,
@@ -29,10 +31,11 @@ export default function EventStudentsPage() {
     const [event, setEvent] = useState(null);
     const [allStudents, setAllStudents] = useState([]);
     const [eventEntries, setEventEntries] = useState([]);
-    const [eventStudentIds, setEventStudentIds] = useState(new Set());
+    const [eventStudentDocIds, setEventStudentDocIds] = useState({});
     const [checkedInStudentIds, setCheckedInStudentIds] = useState(new Set());
     const [loading, setLoading] = useState(true);
     const [printingReports, setPrintingReports] = useState(false);
+    const [removingStudentId, setRemovingStudentId] = useState(null);
 
     const [searchTerm, setSearchTerm] = useState('');
 
@@ -72,7 +75,11 @@ export default function EventStudentsPage() {
         if (!eventId) return;
         const q = query(collection(db, 'eventStudents'), where('eventId', '==', eventId));
         const unsub = onSnapshot(q, snap => {
-            setEventStudentIds(new Set(snap.docs.map(d => d.data().studentId)));
+            const docIds = {};
+            snap.docs.forEach(d => {
+                docIds[d.data().studentId] = d.id;
+            });
+            setEventStudentDocIds(docIds);
         });
         return () => unsub();
     }, [eventId]);
@@ -93,6 +100,11 @@ export default function EventStudentsPage() {
         });
         return () => unsub();
     }, [eventId]);
+
+    const eventStudentIds = useMemo(
+        () => new Set(Object.keys(eventStudentDocIds)),
+        [eventStudentDocIds]
+    );
 
     // Students visible in this event: explicitly added OR checked in at least once
     const eventStudents = useMemo(() => {
@@ -118,6 +130,20 @@ export default function EventStudentsPage() {
             })
             .sort((a, b) => a.lastName.localeCompare(b.lastName));
     }, [allStudents, eventStudentIds, checkedInStudentIds, importSearch]);
+
+    const handleRemoveStudent = async (studentId) => {
+        const eventStudentDocId = eventStudentDocIds[studentId];
+        if (!eventStudentDocId) return;
+
+        setRemovingStudentId(studentId);
+        try {
+            await deleteDoc(doc(db, 'eventStudents', eventStudentDocId));
+        } catch (err) {
+            console.error('Error removing student:', err);
+        } finally {
+            setRemovingStudentId(null);
+        }
+    };
 
     const handleAddStudent = async (e) => {
         e.preventDefault();
@@ -443,12 +469,29 @@ export default function EventStudentsPage() {
                                         )}
                                     </td>
                                     <td className="px-6 py-4 text-right">
-                                        <Link
-                                            to={`/admin/settings/students/${s.id}`}
-                                            className="text-xs font-bold text-primary-600 hover:underline"
-                                        >
-                                            View Details
-                                        </Link>
+                                        <div className="flex items-center justify-end gap-4">
+                                            <Link
+                                                to={`/admin/settings/students/${s.id}`}
+                                                className="text-xs font-bold text-primary-600 hover:underline"
+                                            >
+                                                View Details
+                                            </Link>
+                                            {eventStudentDocIds[s.id] && !checkedInStudentIds.has(s.id) && (
+                                                <button
+                                                    type="button"
+                                                    onClick={() => handleRemoveStudent(s.id)}
+                                                    disabled={removingStudentId === s.id}
+                                                    className="text-xs font-bold text-red-500 hover:text-red-700 disabled:opacity-50"
+                                                >
+                                                    {removingStudentId === s.id ? 'Removing...' : 'Remove'}
+                                                </button>
+                                            )}
+                                            {checkedInStudentIds.has(s.id) && (
+                                                <span className="text-xs text-gray-300" title="Cannot remove a student with time entries">
+                                                    Remove
+                                                </span>
+                                            )}
+                                        </div>
                                     </td>
                                 </tr>
                             ))}

--- a/frontend/src/pages/EventStudentsPage.test.jsx
+++ b/frontend/src/pages/EventStudentsPage.test.jsx
@@ -21,8 +21,10 @@ let addDocMock;
 
 vi.mock('firebase/firestore', () => ({
     collection: vi.fn((db, path) => ({ _collPath: path })),
+    doc: vi.fn((db, col, id) => ({ _docPath: `${col}/${id}` })),
     query: vi.fn((ref) => ref),
     where: vi.fn(() => ({})),
+    deleteDoc: vi.fn().mockResolvedValue(undefined),
     onSnapshot: vi.fn((queryOrRef, callback) => {
         const path = queryOrRef?._collPath;
 
@@ -31,7 +33,7 @@ vi.mock('firebase/firestore', () => ({
         } else if (path === 'students') {
             queueMicrotask(() => callback({ docs: mockStudents.map(s => ({ id: s.id, data: () => s })) }));
         } else if (path === 'eventStudents') {
-            // Only student1 explicitly added to event
+            // student1 explicitly added to event; student2 only has time entries
             queueMicrotask(() => callback({ docs: [{ id: 'es1', data: () => ({ eventId: 'event123', studentId: 'student1' }) }] }));
         } else if (path === 'timeEntries') {
             // student2 checked in via time entries
@@ -211,6 +213,40 @@ describe('EventStudentsPage', () => {
         act(() => { fireEvent.change(searchInput, { target: { value: 'Alice' } }); });
 
         expect(screen.getByText(/1 of 2 students/i)).toBeInTheDocument();
+    });
+
+    it('shows a Remove button for explicitly added students with no time entries', async () => {
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByText('Alice Adams')).toBeInTheDocument();
+        });
+
+        const removeButton = screen.getByRole('button', { name: /^Remove$/ });
+        expect(removeButton).toBeInTheDocument();
+        expect(removeButton).not.toBeDisabled();
+    });
+
+    it('does not show an active Remove button for students with time entries', async () => {
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByText('Bob Brown')).toBeInTheDocument();
+        });
+
+        expect(screen.getAllByRole('button', { name: /^Remove$/ })).toHaveLength(1);
+        expect(screen.getByTitle('Cannot remove a student with time entries')).toBeInTheDocument();
+    });
+
+    it('deletes the eventStudents association when Remove is clicked', async () => {
+        const { deleteDoc, doc } = await import('firebase/firestore');
+
+        renderPage();
+        await waitFor(() => screen.getByRole('button', { name: /^Remove$/ }));
+        fireEvent.click(screen.getByRole('button', { name: /^Remove$/ }));
+
+        await waitFor(() => {
+            expect(doc).toHaveBeenCalledWith({}, 'eventStudents', 'es1');
+            expect(deleteDoc).toHaveBeenCalledTimes(1);
+        });
     });
 
     it('submitting Add Student form calls addDoc twice (student + eventStudents)', async () => {


### PR DESCRIPTION
## Summary
- add a Remove action for event students that were explicitly added but have no time entries
- preserve checked-in students by showing a disabled Remove placeholder instead of deleting history
- add regression coverage for remove-button visibility and deletion behavior

## Verification
- npm run build
- npm test -- EventStudentsPage.test.jsx -t Remove --reporter=verbose (visibility tests passed; Vitest worker later hit JS heap out-of-memory under Node 25)
