### PR TITLE
Revise hours lookup scan flow

### DIFF
--- a/frontend/src/hooks/useQRScanner.js
+++ b/frontend/src/hooks/useQRScanner.js
@@ -9,13 +9,15 @@ import { parseQRData } from '../utils/qrCodeGenerator';
  * @param {Function} options.onError - Callback when scan error occurs
  * @param {number} options.fps - Frames per second (default: 10)
  * @param {Object} options.qrbox - QR box dimensions
+ * @param {boolean} options.validateQrData - Parse QR data before calling onSuccess
  */
 export function useQRScanner(options = {}) {
   const {
     onSuccess,
     onError,
     fps = 10,
-    qrbox = { width: 250, height: 250 }
+    qrbox = { width: 250, height: 250 },
+    validateQrData = true
   } = options;
 
   const [isScanning, setIsScanning] = useState(false);
@@ -86,6 +88,11 @@ export function useQRScanner(options = {}) {
         selectedCamera || { facingMode: 'environment' },
         config,
         (decodedText) => {
+          if (!validateQrData) {
+            onSuccess?.({ rawData: decodedText });
+            return;
+          }
+
           // Parse and validate QR code
           const parsed = parseQRData(decodedText);
 
@@ -116,7 +123,7 @@ export function useQRScanner(options = {}) {
       isScanningRef.current = false;
       setIsScanning(false);
     }
-  }, [cameras, selectedCamera, fps, qrbox, onSuccess, onError, getCameras]);
+  }, [cameras, selectedCamera, fps, qrbox, validateQrData, onSuccess, onError, getCameras]);
 
   /**
    * Stop scanning

--- a/frontend/src/pages/CheckHoursPage.jsx
+++ b/frontend/src/pages/CheckHoursPage.jsx
@@ -26,6 +26,14 @@ function formatTime(value) {
   return date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
 }
 
+function CheckIcon() {
+  return (
+    <svg className="h-4 w-4" aria-hidden="true" viewBox="0 0 20 20" fill="currentColor">
+      <path fillRule="evenodd" d="M16.704 5.29a1 1 0 010 1.42l-7.25 7.25a1 1 0 01-1.415 0l-3.25-3.25a1 1 0 111.415-1.42l2.543 2.543 6.543-6.543a1 1 0 011.414 0z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
 export default function CheckHoursPage() {
   const [lookup, setLookup] = useState(null);
   const [selectedEventId, setSelectedEventId] = useState(null);
@@ -35,7 +43,7 @@ export default function CheckHoursPage() {
 
   const selectedEvent = useMemo(() => {
     if (!lookup?.events?.length) return null;
-    return lookup.events.find((event) => event.id === selectedEventId) || lookup.events[0];
+    return lookup.events.find((event) => event.id === selectedEventId) || null;
   }, [lookup, selectedEventId]);
 
   const loadHours = async (qrData) => {
@@ -53,8 +61,8 @@ export default function CheckHoursPage() {
       }
 
       setLookup(result.data);
-      setSelectedEventId(result.data.scannedEventId || result.data.events?.[0]?.id || null);
-      setStatus({ type: 'success', message: 'Hours loaded' });
+      setSelectedEventId(null);
+      setStatus({ type: 'success', message: 'Badge scanned' });
       await stopScanning();
     } catch (error) {
       setStatus({ type: 'error', message: error.message || 'Unable to load hours' });
@@ -69,6 +77,7 @@ export default function CheckHoursPage() {
       setStatus({ type: 'error', message: error.message || 'Invalid QR code' });
     },
     qrbox: { width: 260, height: 260 },
+    validateQrData: false,
   });
 
   const handleStartScanner = async () => {
@@ -137,9 +146,9 @@ export default function CheckHoursPage() {
             </div>
 
             <form onSubmit={handleManualSubmit} className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
-              <h2 className="text-lg font-black text-gray-900">Enter QR Data</h2>
+              <h2 className="text-lg font-black text-gray-900">Enter Badge Data</h2>
               <label htmlFor="manual-qr-data" className="mt-4 block text-sm font-bold text-gray-700">
-                QR code text
+                QR code text or student ID
               </label>
               <textarea
                 id="manual-qr-data"
@@ -147,14 +156,14 @@ export default function CheckHoursPage() {
                 onChange={(event) => setManualQrData(event.target.value)}
                 rows={4}
                 className="mt-2 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
-                placeholder="studentId|eventId|checksum"
+                placeholder="Scan a badge, or enter the student ID"
               />
               <button
                 type="submit"
                 disabled={!manualQrData.trim() || status.type === 'loading'}
                 className="mt-4 w-full rounded-md bg-gray-900 px-4 py-2 text-sm font-bold text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                Look Up Hours
+                Continue
               </button>
             </form>
           </section>
@@ -195,7 +204,9 @@ export default function CheckHoursPage() {
               </div>
             ) : (
               <div className="grid gap-6 lg:grid-cols-[280px_minmax(0,1fr)]">
-                <nav className="space-y-2" aria-label="Worked events">
+                <div>
+                  <h3 className="mb-3 text-lg font-black text-gray-900">Which event are you interested in?</h3>
+                  <nav className="space-y-2" aria-label="Worked events">
                   {lookup.events.map((event) => (
                     <button
                       key={event.id}
@@ -207,13 +218,17 @@ export default function CheckHoursPage() {
                           : 'border-gray-200 bg-white text-gray-800 hover:border-gray-300 hover:bg-gray-50'
                       }`}
                     >
-                      <span className="block text-sm font-black">{event.name}</span>
+                      <span className="flex items-center justify-between gap-3 text-sm font-black">
+                        {event.name}
+                        {selectedEvent?.id === event.id && <CheckIcon />}
+                      </span>
                       <span className="mt-1 block text-xs font-bold text-gray-500">{formatHours(event.totalHours)}</span>
                     </button>
                   ))}
-                </nav>
+                  </nav>
+                </div>
 
-                {selectedEvent && (
+                {selectedEvent ? (
                   <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
                     <div className="border-b border-gray-200 p-4 sm:p-6">
                       <h3 className="text-xl font-black text-gray-900">{selectedEvent.name}</h3>
@@ -234,6 +249,10 @@ export default function CheckHoursPage() {
                         </div>
                       ))}
                     </div>
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-sm font-semibold text-gray-500">
+                    Choose an event to see the credited hours for that event.
                   </div>
                 )}
               </div>

--- a/frontend/src/pages/CheckHoursPage.test.jsx
+++ b/frontend/src/pages/CheckHoursPage.test.jsx
@@ -73,50 +73,51 @@ describe('CheckHoursPage', () => {
     });
   });
 
-  it('looks up QR data and shows the scanned student profile', async () => {
+  it('looks up badge data and shows the scanned student profile', async () => {
     render(<CheckHoursPage />);
 
     act(() => {
       fireEvent.change(screen.getByLabelText(/QR code text/i), {
-        target: { value: 'student1|event2|abc123' },
+        target: { value: 'student1' },
       });
     });
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Look Up Hours/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
     });
 
     await waitFor(() => {
       expect(screen.getByText('Jane Smith')).toBeInTheDocument();
     });
 
-    expect(mockCheckHoursLogged).toHaveBeenCalledWith({ qrData: 'student1|event2|abc123' });
+    expect(mockCheckHoursLogged).toHaveBeenCalledWith({ qrData: 'student1' });
     expect(screen.getByText('Central High')).toBeInTheDocument();
     expect(screen.getByText('All Credited Hours')).toBeInTheDocument();
     expect(screen.getByText('5.00 hours')).toBeInTheDocument();
   });
 
-  it('defaults to the scanned event and can switch events', async () => {
+  it('asks which event to inspect before showing event details', async () => {
     render(<CheckHoursPage />);
 
     act(() => {
       fireEvent.change(screen.getByLabelText(/QR code text/i), {
-        target: { value: 'student1|event2|abc123' },
+        target: { value: 'student1' },
       });
     });
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Look Up Hours/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'VBS 2026' })).toBeInTheDocument();
+      expect(screen.getByText(/Which event are you interested in/i)).toBeInTheDocument();
     });
+    expect(screen.getByText(/Choose an event to see the credited hours/i)).toBeInTheDocument();
+    expect(screen.queryByText('Work Hours')).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /VBS 2026/i }));
+    });
+
+    expect(screen.getByRole('heading', { name: 'VBS 2026' })).toBeInTheDocument();
     expect(screen.getByText('Work Hours')).toBeInTheDocument();
-
-    act(() => {
-      fireEvent.click(screen.getByRole('button', { name: /Setup Day/i }));
-    });
-
-    expect(screen.getByRole('heading', { name: 'Setup Day' })).toBeInTheDocument();
-    expect(screen.getByText('Decorating')).toBeInTheDocument();
   });
 });

--- a/functions/src/checkHoursLogged.js
+++ b/functions/src/checkHoursLogged.js
@@ -13,11 +13,22 @@ function generateChecksum(studentId, eventId) {
 }
 
 function parseQRData(qrData) {
-  if (typeof qrData !== 'string') {
+  if (typeof qrData !== 'string' || !qrData.trim()) {
     return { isValid: false, error: 'Missing QR data' };
   }
 
-  const parts = qrData.split('|');
+  const trimmed = qrData.trim();
+  const parts = trimmed.split('|');
+
+  if (parts.length === 1) {
+    return {
+      studentId: trimmed,
+      eventId: null,
+      checksum: null,
+      isValid: true,
+    };
+  }
+
   if (parts.length !== 3) {
     return { isValid: false, error: 'Invalid QR code format' };
   }
@@ -77,8 +88,9 @@ function publicStudentProfile(student, studentId) {
 /**
  * Public QR-backed hour lookup for students.
  *
- * The QR checksum gates access to a single student. The response intentionally
- * returns only hour-report fields, not contact or emergency data.
+ * Accepts both current event-specific QR data and older student-id-only badges.
+ * The response intentionally returns only hour-report fields, not contact or
+ * emergency data.
  */
 export const checkHoursLogged = onCall({ cors: true }, async (request) => {
   const { qrData } = request.data || {};

--- a/functions/test/checkHoursLogged.test.js
+++ b/functions/test/checkHoursLogged.test.js
@@ -151,6 +151,17 @@ describe('checkHoursLogged Cloud Function', () => {
     expect(result.events.find((event) => event.id === 'event456').entries).toHaveLength(1);
   });
 
+  it('accepts student-id-only badge data', async () => {
+    const result = await checkHoursLogged({
+      data: { qrData: 'student123' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.scannedEventId).toBeNull();
+    expect(result.student.fullName).toBe('Jane Smith');
+    expect(result.totalHours).toBe(5);
+  });
+
   it('rejects QR data with an invalid checksum', async () => {
     await expect(checkHoursLogged({
       data: { qrData: 'student123|event456|bad' },


### PR DESCRIPTION
## Summary
- update /hours to behave as a scan-first flow before asking which event to inspect
- allow the hours lookup callable to accept both event-specific QR payloads and student-id-only badge data
- let the shared QR scanner optionally return raw scan data while keeping validation enabled for the volunteer scanner

## Validation
- npm test -- CheckHoursPage.test.jsx
- npm test -- --runInBand checkHoursLogged.test.js
- npm test -- useQRScanner.test.js
- npm run build
- local emulator smoke test with seeded student ID 5PdunWUm1oWomQUTC1Sk