### PR TITLE
Implement Daily Review quick check-in

### DIFF
--- a/frontend/src/components/DailyReview/DailyReview.test.jsx
+++ b/frontend/src/components/DailyReview/DailyReview.test.jsx
@@ -240,7 +240,7 @@ describe('DailyReview', () => {
         expect(screen.getAllByText('Adams, Alice').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('Brown, Bob').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('Not Checked In').length).toBeGreaterThanOrEqual(1);
-        expect(screen.getAllByText('No entry').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByRole('button', { name: /check in alice adams/i }).length).toBeGreaterThanOrEqual(1);
       });
     });
 

--- a/frontend/src/components/DailyReview/TimeEntryCard.jsx
+++ b/frontend/src/components/DailyReview/TimeEntryCard.jsx
@@ -11,6 +11,7 @@ import Button from '../common/Button';
  * @param {Function} getStatusDisplay - Function to get status display text
  * @param {Function} getStatusClass - Function to get status CSS class
  * @param {Function} onEdit - Callback when edit button is clicked
+ * @param {Function} onQuickCheckIn - Callback when check-in button is clicked
  * @param {Function} onForceCheckout - Callback when force checkout button is clicked
  * @param {Function} onVoid - Callback when void button is clicked
  * @param {Function} onRestore - Callback when restore button is clicked
@@ -22,6 +23,7 @@ export default function TimeEntryCard({
   getStatusDisplay,
   getStatusClass,
   onEdit,
+  onQuickCheckIn,
   onForceCheckout,
   onVoid,
   onRestore
@@ -142,7 +144,14 @@ export default function TimeEntryCard({
       {/* Actions */}
       <div className="flex gap-2 pt-2 border-t border-gray-100">
         {isNoCheckIn ? (
-          <span className="text-sm text-gray-500">No entry</span>
+          <Button
+            size="sm"
+            variant="success"
+            onClick={() => onQuickCheckIn(entry)}
+            aria-label={`Check in ${entry.student.firstName} ${entry.student.lastName}`}
+          >
+            Check In
+          </Button>
         ) : isVoided ? (
           <Button
             size="sm"
@@ -175,9 +184,9 @@ export default function TimeEntryCard({
                 size="sm"
                 variant="danger"
                 onClick={() => onForceCheckout(entry)}
-                aria-label={`Force checkout for ${entry.student.firstName} ${entry.student.lastName}`}
+                aria-label={`Checkout for ${entry.student.firstName} ${entry.student.lastName}`}
               >
-                Force Out
+                Checkout
               </Button>
             )}
           </>

--- a/frontend/src/components/DailyReview/TimeEntryCard.test.jsx
+++ b/frontend/src/components/DailyReview/TimeEntryCard.test.jsx
@@ -65,6 +65,7 @@ describe('TimeEntryCard', () => {
     getStatusDisplay: mockGetStatusDisplay,
     getStatusClass: mockGetStatusClass,
     onEdit: vi.fn(),
+    onQuickCheckIn: vi.fn(),
     onForceCheckout: vi.fn()
   };
 
@@ -111,10 +112,10 @@ describe('TimeEntryCard', () => {
       expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
     });
 
-    it('should not render Force Out button when checked out', () => {
+    it('should not render Checkout button when checked out', () => {
       render(<TimeEntryCard {...defaultProps} />);
 
-      expect(screen.queryByRole('button', { name: /force checkout/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^checkout/i })).not.toBeInTheDocument();
     });
   });
 
@@ -131,10 +132,10 @@ describe('TimeEntryCard', () => {
       expect(screen.getByText('Not checked out')).toBeInTheDocument();
     });
 
-    it('should render Force Out button when not checked out', () => {
+    it('should render Checkout button when not checked out', () => {
       render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} />);
 
-      expect(screen.getByRole('button', { name: /force checkout/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^checkout/i })).toBeInTheDocument();
     });
 
     it('should display No Checkout status', () => {
@@ -220,16 +221,28 @@ describe('TimeEntryCard', () => {
       expect(onEdit).toHaveBeenCalledWith(mockEntry);
     });
 
-    it('should call onForceCheckout when Force Out button is clicked', async () => {
+    it('should call onForceCheckout when Checkout button is clicked', async () => {
       const user = userEvent.setup();
       const onForceCheckout = vi.fn();
       const entryNoCheckout = { ...mockEntry, checkOutTime: null };
 
       render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} onForceCheckout={onForceCheckout} />);
 
-      await user.click(screen.getByRole('button', { name: /force checkout/i }));
+      await user.click(screen.getByRole('button', { name: /^checkout/i }));
 
       expect(onForceCheckout).toHaveBeenCalledWith(entryNoCheckout);
+    });
+
+    it('should call onQuickCheckIn when Check In button is clicked', async () => {
+      const user = userEvent.setup();
+      const onQuickCheckIn = vi.fn();
+      const entryNoCheckIn = { ...mockEntry, checkInTime: null, checkOutTime: null, isNoCheckIn: true };
+
+      render(<TimeEntryCard {...defaultProps} entry={entryNoCheckIn} onQuickCheckIn={onQuickCheckIn} />);
+
+      await user.click(screen.getByRole('button', { name: /check in john doe/i }));
+
+      expect(onQuickCheckIn).toHaveBeenCalledWith(entryNoCheckIn);
     });
   });
 
@@ -258,12 +271,12 @@ describe('TimeEntryCard', () => {
       expect(editButton).toHaveAttribute('aria-label', 'Edit time entry for John Doe');
     });
 
-    it('should have aria-label on Force Out button when visible', () => {
+    it('should have aria-label on Checkout button when visible', () => {
       const entryNoCheckout = { ...mockEntry, checkOutTime: null };
       render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} />);
 
-      const forceOutButton = screen.getByRole('button', { name: /force checkout/i });
-      expect(forceOutButton).toHaveAttribute('aria-label', 'Force checkout for John Doe');
+      const checkoutButton = screen.getByRole('button', { name: /^checkout/i });
+      expect(checkoutButton).toHaveAttribute('aria-label', 'Checkout for John Doe');
     });
   });
 

--- a/frontend/src/components/DailyReview/index.jsx
+++ b/frontend/src/components/DailyReview/index.jsx
@@ -15,7 +15,7 @@ import TimeEntryCard from './TimeEntryCard';
  * Per PRD Section 3.5.2: Daily Review (Nightly)
  * - Review time entries
  * - Flag early/late times
- * - Force checkout for students who forgot
+ * - Checkout students who forgot
  * - Force all checkout for end of event
  * - Export CSV/PDF
  */
@@ -29,6 +29,17 @@ export default function DailyReview() {
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [exporting, setExporting] = useState(false);
+
+  // Quick check-in modal state
+  const [quickCheckInModal, setQuickCheckInModal] = useState({
+    isOpen: false,
+    entry: null,
+    activityId: '',
+    checkInTime: '',
+    reason: '',
+    loading: false,
+    error: null
+  });
 
   // Force checkout modal state
   const [forceCheckoutModal, setForceCheckoutModal] = useState({
@@ -236,6 +247,38 @@ export default function DailyReview() {
     return activity?.endTime || currentEvent?.typicalEndTime || '15:00';
   };
 
+  const getLocalDateTimeValue = (dateString, timeString) => {
+    const [hours = '09', mins = '00'] = (timeString || '09:00').split(':');
+    const [yr, mo, dy] = dateString.split('-').map(Number);
+    const date = new Date(yr, mo - 1, dy);
+    date.setHours(parseInt(hours), parseInt(mins), 0, 0);
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hh = String(date.getHours()).padStart(2, '0');
+    const mm = String(date.getMinutes()).padStart(2, '0');
+    return `${year}-${month}-${day}T${hh}:${mm}`;
+  };
+
+  const getDefaultActivity = () => currentEvent?.activities?.[0] || null;
+
+  // Open quick check-in modal
+  const openQuickCheckInModal = (entry) => {
+    const defaultActivity = getDefaultActivity();
+    const startTime = defaultActivity?.startTime || currentEvent?.typicalStartTime || '09:00';
+
+    setQuickCheckInModal({
+      isOpen: true,
+      entry,
+      activityId: defaultActivity?.id || '',
+      checkInTime: getLocalDateTimeValue(selectedDate, startTime),
+      reason: '',
+      loading: false,
+      error: null
+    });
+  };
+
   // Open force checkout modal
   const openForceCheckoutModal = (entry) => {
     // Default to activity end time
@@ -353,6 +396,47 @@ export default function DailyReview() {
         ...prev,
         loading: false,
         error: error.message || 'Failed to force checkout'
+      }));
+    }
+  };
+
+  // Handle quick check-in
+  const handleQuickCheckIn = async () => {
+    if (!quickCheckInModal.entry || !quickCheckInModal.activityId || !quickCheckInModal.checkInTime) {
+      setQuickCheckInModal(prev => ({ ...prev, error: 'Activity and check-in time are required' }));
+      return;
+    }
+
+    setQuickCheckInModal(prev => ({ ...prev, loading: true, error: null }));
+
+    try {
+      const quickCheckInFunc = httpsCallable(functions, 'quickCheckIn');
+      const result = await quickCheckInFunc({
+        studentId: quickCheckInModal.entry.studentId,
+        eventId: currentEvent.id,
+        activityId: quickCheckInModal.activityId,
+        date: selectedDate,
+        checkInTime: new Date(quickCheckInModal.checkInTime).toISOString(),
+        reason: quickCheckInModal.reason
+      });
+
+      if (result.data.success) {
+        setQuickCheckInModal({
+          isOpen: false,
+          entry: null,
+          activityId: '',
+          checkInTime: '',
+          reason: '',
+          loading: false,
+          error: null
+        });
+      }
+    } catch (error) {
+      console.error('Quick check-in error:', error);
+      setQuickCheckInModal(prev => ({
+        ...prev,
+        loading: false,
+        error: error.message || 'Failed to check in student'
       }));
     }
   };
@@ -912,7 +996,14 @@ export default function DailyReview() {
                     <td className="px-4 py-3">
                       <div className="flex flex-wrap gap-2">
                         {entry.isNoCheckIn ? (
-                          <span className="text-sm text-gray-500">No entry</span>
+                          <Button
+                            size="sm"
+                            variant="success"
+                            onClick={() => openQuickCheckInModal(entry)}
+                            aria-label={`Check in ${entry.student.firstName} ${entry.student.lastName}`}
+                          >
+                            Check In
+                          </Button>
                         ) : entry.isVoided ? (
                           <Button
                             size="sm"
@@ -945,9 +1036,9 @@ export default function DailyReview() {
                                 size="sm"
                                 variant="danger"
                                 onClick={() => openForceCheckoutModal(entry)}
-                                aria-label={`Force checkout for ${entry.student.firstName} ${entry.student.lastName}`}
+                                aria-label={`Checkout for ${entry.student.firstName} ${entry.student.lastName}`}
                               >
-                                Force Out
+                                Checkout
                               </Button>
                             )}
                           </>
@@ -984,6 +1075,7 @@ export default function DailyReview() {
                   getStatusDisplay={getStatusDisplay}
                   getStatusClass={getStatusClass}
                   onEdit={openEditModal}
+                  onQuickCheckIn={openQuickCheckInModal}
                   onForceCheckout={openForceCheckoutModal}
                   onVoid={openVoidModal}
                   onRestore={handleRestoreEntry}
@@ -1022,11 +1114,117 @@ export default function DailyReview() {
         </div>
       </div>
 
+      {/* Quick Check-In Modal */}
+      <Modal
+        isOpen={quickCheckInModal.isOpen}
+        onClose={() => setQuickCheckInModal({ ...quickCheckInModal, isOpen: false })}
+        title="Check In"
+        size="md"
+        footer={
+          <>
+            <Button
+              variant="secondary"
+              onClick={() => setQuickCheckInModal({ ...quickCheckInModal, isOpen: false })}
+              disabled={quickCheckInModal.loading}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="success"
+              onClick={handleQuickCheckIn}
+              loading={quickCheckInModal.loading}
+            >
+              Check In
+            </Button>
+          </>
+        }
+      >
+        {quickCheckInModal.entry && (
+          <div className="space-y-4">
+            <div>
+              <p className="text-gray-600">
+                Check in:{' '}
+                <span className="font-bold text-gray-900">
+                  {quickCheckInModal.entry.student?.firstName} {quickCheckInModal.entry.student?.lastName}
+                </span>
+              </p>
+              <p className="text-sm text-gray-500 mt-1">
+                Date: {formatDate(selectedDate)}
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Activity <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={quickCheckInModal.activityId}
+                onChange={(e) => {
+                  const activity = activityMap[e.target.value];
+                  setQuickCheckInModal(prev => ({
+                    ...prev,
+                    activityId: e.target.value,
+                    checkInTime: getLocalDateTimeValue(
+                      selectedDate,
+                      activity?.startTime || currentEvent?.typicalStartTime || '09:00'
+                    )
+                  }));
+                }}
+                className="input-field w-full"
+              >
+                <option value="">Select activity</option>
+                {(currentEvent?.activities || []).map(activity => (
+                  <option key={activity.id} value={activity.id}>
+                    {activity.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Check-In Time <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="datetime-local"
+                value={quickCheckInModal.checkInTime}
+                onChange={(e) => setQuickCheckInModal(prev => ({
+                  ...prev,
+                  checkInTime: e.target.value
+                }))}
+                className="input-field w-full"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Reason or Note
+              </label>
+              <textarea
+                value={quickCheckInModal.reason}
+                onChange={(e) => setQuickCheckInModal(prev => ({
+                  ...prev,
+                  reason: e.target.value
+                }))}
+                placeholder="e.g., Missed scan-in, entered from roster review"
+                className="input-field w-full h-24 resize-none"
+              />
+            </div>
+
+            {quickCheckInModal.error && (
+              <div className="text-red-600 text-sm">
+                {quickCheckInModal.error}
+              </div>
+            )}
+          </div>
+        )}
+      </Modal>
+
       {/* Force Checkout Modal */}
       <Modal
         isOpen={forceCheckoutModal.isOpen}
         onClose={() => setForceCheckoutModal({ ...forceCheckoutModal, isOpen: false })}
-        title="Force Check-Out"
+        title="Checkout"
         size="md"
         footer={
           <>
@@ -1042,7 +1240,7 @@ export default function DailyReview() {
               onClick={handleForceCheckout}
               loading={forceCheckoutModal.loading}
             >
-              Force Check-Out
+              Checkout
             </Button>
           </>
         }
@@ -1051,7 +1249,7 @@ export default function DailyReview() {
           <div className="space-y-4">
             <div>
               <p className="text-gray-600">
-                Force checkout for:{' '}
+                Checkout:{' '}
                 <span className="font-bold text-gray-900">
                   {forceCheckoutModal.entry.student?.firstName} {forceCheckoutModal.entry.student?.lastName}
                 </span>
@@ -1084,7 +1282,7 @@ export default function DailyReview() {
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Reason for Force Checkout <span className="text-red-500">*</span>
+                Reason for Checkout <span className="text-red-500">*</span>
               </label>
               <textarea
                 value={forceCheckoutModal.reason}

--- a/functions/index.js
+++ b/functions/index.js
@@ -19,7 +19,7 @@ export { generateForms } from './src/generateForms.js';
 export { createUser, updateUser, deleteUser, listUsers, resetUserPassword } from './src/userManagement.js';
 
 // Daily Review Functions (PRD Section 3.5.2)
-export { forceCheckOut, forceAllCheckOut, getDailyReviewSummary } from './src/dailyReview.js';
+export { quickCheckIn, forceCheckOut, forceAllCheckOut, getDailyReviewSummary } from './src/dailyReview.js';
 
 // Void/Restore Functions (Soft Delete)
 export { voidTimeEntry, restoreTimeEntry } from './src/voidEntry.js';

--- a/functions/src/dailyReview.js
+++ b/functions/src/dailyReview.js
@@ -10,6 +10,143 @@ const toDate = (timestamp) => {
   return new Date(timestamp);
 };
 
+const getFlagsForCheckIn = (checkInTime, typicalStart = '09:00') => {
+  const flags = [];
+  const [hour, min] = typicalStart.split(':');
+  const typical = new Date(checkInTime);
+  typical.setHours(parseInt(hour), parseInt(min), 0, 0);
+
+  if (checkInTime < (typical.getTime() - (15 * 60 * 1000))) {
+    flags.push('early_arrival');
+  }
+
+  return flags;
+};
+
+/**
+ * Quick Check-In Cloud Function
+ * Creates an open time entry from Daily Review for a student who missed scan-in.
+ *
+ * @param {Object} request.data
+ * @param {string} request.data.studentId - Student ID
+ * @param {string} request.data.eventId - Event ID
+ * @param {string} request.data.activityId - Activity ID
+ * @param {string} request.data.date - Date (YYYY-MM-DD)
+ * @param {string} request.data.checkInTime - ISO timestamp for check-in
+ * @param {string} request.data.reason - Optional reason/note
+ */
+export const quickCheckIn = onCall({ cors: true }, async (request) => {
+  const { studentId, eventId, activityId, date, checkInTime, reason } = request.data;
+
+  if (!studentId || !eventId || !activityId || !date || !checkInTime) {
+    throw new HttpsError('invalid-argument', 'Missing required fields: studentId, eventId, activityId, date, and checkInTime');
+  }
+
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'User must be authenticated');
+  }
+
+  const parsedCheckInTime = new Date(checkInTime);
+  if (isNaN(parsedCheckInTime.getTime())) {
+    throw new HttpsError('invalid-argument', 'Invalid check-in time');
+  }
+
+  const checkInDate = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(parsedCheckInTime);
+  if (checkInDate !== date) {
+    throw new HttpsError('invalid-argument', 'Check-in time must match selected date');
+  }
+
+  const db = getFirestore();
+  const userId = request.auth.uid;
+  const userName = request.auth.token?.name || null;
+
+  try {
+    const studentDoc = await db.collection('students').doc(studentId).get();
+    if (!studentDoc.exists) {
+      throw new HttpsError('not-found', 'Student not found');
+    }
+    const student = studentDoc.data();
+
+    const eventDoc = await db.collection('events').doc(eventId).get();
+    if (!eventDoc.exists) {
+      throw new HttpsError('not-found', 'Event not found');
+    }
+    const event = eventDoc.data();
+    const activity = (event.activities || []).find(a => a.id === activityId);
+    if (!activity) {
+      throw new HttpsError('not-found', 'Activity not found for event');
+    }
+
+    const existingQuery = await db.collection('timeEntries')
+      .where('studentId', '==', studentId)
+      .where('eventId', '==', eventId)
+      .where('date', '==', date)
+      .get();
+
+    const hasExistingActiveEntry = existingQuery.docs.some(doc => !doc.data().isVoided);
+    if (hasExistingActiveEntry) {
+      throw new HttpsError('already-exists', 'Student already has a time entry for this date');
+    }
+
+    const checkInTimestamp = Timestamp.fromDate(parsedCheckInTime);
+    const flags = getFlagsForCheckIn(parsedCheckInTime, activity.startTime || event.typicalStartTime || '09:00');
+    const note = reason?.trim();
+    const changeDescription = note
+      ? `Quick Check-In at ${parsedCheckInTime.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}. Reason: ${note}`
+      : `Quick Check-In at ${parsedCheckInTime.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`;
+
+    const entry = {
+      studentId,
+      eventId,
+      activityId,
+      date,
+      checkInTime: checkInTimestamp,
+      checkInBy: userId,
+      checkInByName: userName,
+      checkInMethod: 'daily_review',
+      checkOutTime: null,
+      checkOutBy: null,
+      checkOutMethod: null,
+      hoursWorked: null,
+      rawMinutes: null,
+      reviewStatus: flags.length > 0 ? 'flagged' : 'pending',
+      flags,
+      modifiedBy: userId,
+      modificationReason: changeDescription,
+      modifiedAt: Timestamp.now(),
+      isVoided: false,
+      voidReason: null,
+      voidedAt: null,
+      createdAt: Timestamp.now(),
+      changeLog: [{
+        timestamp: new Date().toISOString(),
+        modifiedBy: userId,
+        type: 'quick_checkin',
+        newCheckInTime: parsedCheckInTime.toISOString(),
+        reason: note || null,
+        description: changeDescription
+      }]
+    };
+
+    const docRef = await db.collection('timeEntries').add(entry);
+
+    return {
+      success: true,
+      entryId: docRef.id,
+      studentName: `${student.firstName} ${student.lastName}`,
+      checkInTime: parsedCheckInTime.toISOString(),
+      flags,
+      message: `Check-in recorded for ${student.firstName} ${student.lastName}`
+    };
+  } catch (error) {
+    console.error('Quick check-in error:', error);
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    throw new HttpsError('internal', error.message);
+  }
+});
+
 /**
  * Force Check-Out Cloud Function
  * Per PRD Section 3.5.2: Daily Review (Nightly)

--- a/functions/test/dailyReview.test.js
+++ b/functions/test/dailyReview.test.js
@@ -58,6 +58,7 @@ const mockCollection = jest.fn();
 const mockDoc = jest.fn();
 const mockWhere = jest.fn();
 const mockGet = jest.fn();
+const mockAdd = jest.fn();
 const mockBatch = jest.fn();
 const mockBatchUpdate = jest.fn();
 const mockBatchCommit = jest.fn().mockResolvedValue(undefined);
@@ -82,6 +83,136 @@ jest.unstable_mockModule('firebase-functions/v2/https', () => ({
     }
   },
 }));
+
+describe('quickCheckIn Cloud Function', () => {
+  let quickCheckIn;
+
+  beforeAll(async () => {
+    const dailyReviewModule = await import('../src/dailyReview.js');
+    quickCheckIn = dailyReviewModule.quickCheckIn;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const queryChain = {
+      where: mockWhere,
+      get: mockGet,
+    };
+
+    mockCollection.mockReturnValue({
+      doc: mockDoc,
+      where: mockWhere,
+      add: mockAdd,
+    });
+    mockDoc.mockReturnValue({ get: mockGet });
+    mockWhere.mockReturnValue(queryChain);
+    mockAdd.mockResolvedValue({ id: 'entry123' });
+  });
+
+  it('should throw error when required fields are missing', async () => {
+    const request = {
+      data: {
+        studentId: 'student123',
+        eventId: 'event123',
+      },
+      auth: { uid: 'admin123' },
+    };
+
+    await expect(quickCheckIn(request)).rejects.toThrow('Missing required fields');
+  });
+
+  it('should throw error when user is not authenticated', async () => {
+    const request = {
+      data: {
+        studentId: 'student123',
+        eventId: 'event123',
+        activityId: 'activity1',
+        date: '2026-06-15',
+        checkInTime: '2026-06-15T09:00:00Z',
+      },
+    };
+
+    await expect(quickCheckIn(request)).rejects.toThrow('User must be authenticated');
+  });
+
+  it('should throw error when check-in time does not match selected date', async () => {
+    const request = {
+      data: {
+        studentId: 'student123',
+        eventId: 'event123',
+        activityId: 'activity1',
+        date: '2026-06-15',
+        checkInTime: '2026-06-16T09:00:00Z',
+      },
+      auth: { uid: 'admin123' },
+    };
+
+    await expect(quickCheckIn(request)).rejects.toThrow('Check-in time must match selected date');
+  });
+
+  it('should create an open time entry', async () => {
+    mockGet
+      .mockResolvedValueOnce(mockStudentDoc)
+      .mockResolvedValueOnce(mockEventDoc)
+      .mockResolvedValueOnce({ docs: [] });
+
+    const request = {
+      data: {
+        studentId: 'student123',
+        eventId: 'event123',
+        activityId: 'activity1',
+        date: '2026-06-15',
+        checkInTime: '2026-06-15T09:00:00Z',
+        reason: 'Missed scan-in',
+      },
+      auth: { uid: 'admin123', token: { name: 'Admin User' } },
+    };
+
+    const result = await quickCheckIn(request);
+
+    expect(result.success).toBe(true);
+    expect(result.entryId).toBe('entry123');
+    expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({
+      studentId: 'student123',
+      eventId: 'event123',
+      activityId: 'activity1',
+      date: '2026-06-15',
+      checkInBy: 'admin123',
+      checkInByName: 'Admin User',
+      checkInMethod: 'daily_review',
+      checkOutTime: null,
+      hoursWorked: null,
+      rawMinutes: null,
+      isVoided: false,
+      modificationReason: expect.stringContaining('Missed scan-in'),
+    }));
+  });
+
+  it('should reject a duplicate active time entry for the date', async () => {
+    mockGet
+      .mockResolvedValueOnce(mockStudentDoc)
+      .mockResolvedValueOnce(mockEventDoc)
+      .mockResolvedValueOnce({
+        docs: [
+          { data: () => ({ isVoided: false }) },
+        ],
+      });
+
+    const request = {
+      data: {
+        studentId: 'student123',
+        eventId: 'event123',
+        activityId: 'activity1',
+        date: '2026-06-15',
+        checkInTime: '2026-06-15T09:00:00Z',
+      },
+      auth: { uid: 'admin123' },
+    };
+
+    await expect(quickCheckIn(request)).rejects.toThrow('Student already has a time entry for this date');
+  });
+});
 
 describe('forceCheckOut Cloud Function', () => {
   let forceCheckOut;


### PR DESCRIPTION
## Summary
- add a Daily Review quick check-in callable for roster students without a time entry
- add Check In controls and modal with activity, time, and optional reason
- relabel single-row Force Out action to Checkout across desktop/mobile review UI

Closes #77

## Tests
- npm test -- dailyReview.test.js (functions)
- npm test -- DailyReview TimeEntryCard (frontend)
- npm test (functions)
- npm run build (frontend)