### PR TITLE
Fix Event Students report printing

### DIFF
--- a/frontend/src/components/DailyReview/DailyReview.test.jsx
+++ b/frontend/src/components/DailyReview/DailyReview.test.jsx
@@ -240,7 +240,7 @@ describe('DailyReview', () => {
         expect(screen.getAllByText('Adams, Alice').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('Brown, Bob').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('Not Checked In').length).toBeGreaterThanOrEqual(1);
-        expect(screen.getAllByText('No entry').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByRole('button', { name: /check in alice adams/i }).length).toBeGreaterThanOrEqual(1);
       });
     });
 

--- a/frontend/src/components/DailyReview/TimeEntryCard.jsx
+++ b/frontend/src/components/DailyReview/TimeEntryCard.jsx
@@ -11,6 +11,7 @@ import Button from '../common/Button';
  * @param {Function} getStatusDisplay - Function to get status display text
  * @param {Function} getStatusClass - Function to get status CSS class
  * @param {Function} onEdit - Callback when edit button is clicked
+ * @param {Function} onQuickCheckIn - Callback when check-in button is clicked
  * @param {Function} onForceCheckout - Callback when force checkout button is clicked
  * @param {Function} onVoid - Callback when void button is clicked
  * @param {Function} onRestore - Callback when restore button is clicked
@@ -22,6 +23,7 @@ export default function TimeEntryCard({
   getStatusDisplay,
   getStatusClass,
   onEdit,
+  onQuickCheckIn,
   onForceCheckout,
   onVoid,
   onRestore
@@ -142,7 +144,14 @@ export default function TimeEntryCard({
       {/* Actions */}
       <div className="flex gap-2 pt-2 border-t border-gray-100">
         {isNoCheckIn ? (
-          <span className="text-sm text-gray-500">No entry</span>
+          <Button
+            size="sm"
+            variant="success"
+            onClick={() => onQuickCheckIn(entry)}
+            aria-label={`Check in ${entry.student.firstName} ${entry.student.lastName}`}
+          >
+            Check In
+          </Button>
         ) : isVoided ? (
           <Button
             size="sm"
@@ -175,9 +184,9 @@ export default function TimeEntryCard({
                 size="sm"
                 variant="danger"
                 onClick={() => onForceCheckout(entry)}
-                aria-label={`Force checkout for ${entry.student.firstName} ${entry.student.lastName}`}
+                aria-label={`Checkout for ${entry.student.firstName} ${entry.student.lastName}`}
               >
-                Force Out
+                Checkout
               </Button>
             )}
           </>

--- a/frontend/src/components/DailyReview/TimeEntryCard.test.jsx
+++ b/frontend/src/components/DailyReview/TimeEntryCard.test.jsx
@@ -65,6 +65,7 @@ describe('TimeEntryCard', () => {
     getStatusDisplay: mockGetStatusDisplay,
     getStatusClass: mockGetStatusClass,
     onEdit: vi.fn(),
+    onQuickCheckIn: vi.fn(),
     onForceCheckout: vi.fn()
   };
 
@@ -111,10 +112,10 @@ describe('TimeEntryCard', () => {
       expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
     });
 
-    it('should not render Force Out button when checked out', () => {
+    it('should not render Checkout button when checked out', () => {
       render(<TimeEntryCard {...defaultProps} />);
 
-      expect(screen.queryByRole('button', { name: /force checkout/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^checkout/i })).not.toBeInTheDocument();
     });
   });
 
@@ -131,10 +132,10 @@ describe('TimeEntryCard', () => {
       expect(screen.getByText('Not checked out')).toBeInTheDocument();
     });
 
-    it('should render Force Out button when not checked out', () => {
+    it('should render Checkout button when not checked out', () => {
       render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} />);
 
-      expect(screen.getByRole('button', { name: /force checkout/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^checkout/i })).toBeInTheDocument();
     });
 
     it('should display No Checkout status', () => {
@@ -220,16 +221,28 @@ describe('TimeEntryCard', () => {
       expect(onEdit).toHaveBeenCalledWith(mockEntry);
     });
 
-    it('should call onForceCheckout when Force Out button is clicked', async () => {
+    it('should call onForceCheckout when Checkout button is clicked', async () => {
       const user = userEvent.setup();
       const onForceCheckout = vi.fn();
       const entryNoCheckout = { ...mockEntry, checkOutTime: null };
 
       render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} onForceCheckout={onForceCheckout} />);
 
-      await user.click(screen.getByRole('button', { name: /force checkout/i }));
+      await user.click(screen.getByRole('button', { name: /^checkout/i }));
 
       expect(onForceCheckout).toHaveBeenCalledWith(entryNoCheckout);
+    });
+
+    it('should call onQuickCheckIn when Check In button is clicked', async () => {
+      const user = userEvent.setup();
+      const onQuickCheckIn = vi.fn();
+      const entryNoCheckIn = { ...mockEntry, checkInTime: null, checkOutTime: null, isNoCheckIn: true };
+
+      render(<TimeEntryCard {...defaultProps} entry={entryNoCheckIn} onQuickCheckIn={onQuickCheckIn} />);
+
+      await user.click(screen.getByRole('button', { name: /check in john doe/i }));
+
+      expect(onQuickCheckIn).toHaveBeenCalledWith(entryNoCheckIn);
     });
   });
 
@@ -258,12 +271,12 @@ describe('TimeEntryCard', () => {
       expect(editButton).toHaveAttribute('aria-label', 'Edit time entry for John Doe');
     });
 
-    it('should have aria-label on Force Out button when visible', () => {
+    it('should have aria-label on Checkout button when visible', () => {
       const entryNoCheckout = { ...mockEntry, checkOutTime: null };
       render(<TimeEntryCard {...defaultProps} entry={entryNoCheckout} />);
 
-      const forceOutButton = screen.getByRole('button', { name: /force checkout/i });
-      expect(forceOutButton).toHaveAttribute('aria-label', 'Force checkout for John Doe');
+      const checkoutButton = screen.getByRole('button', { name: /^checkout/i });
+      expect(checkoutButton).toHaveAttribute('aria-label', 'Checkout for John Doe');
     });
   });
 

--- a/frontend/src/components/DailyReview/index.jsx
+++ b/frontend/src/components/DailyReview/index.jsx
@@ -15,7 +15,7 @@ import TimeEntryCard from './TimeEntryCard';
  * Per PRD Section 3.5.2: Daily Review (Nightly)
  * - Review time entries
  * - Flag early/late times
- * - Force checkout for students who forgot
+ * - Checkout students who forgot
  * - Force all checkout for end of event
  * - Export CSV/PDF
  */
@@ -29,6 +29,17 @@ export default function DailyReview() {
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [exporting, setExporting] = useState(false);
+
+  // Quick check-in modal state
+  const [quickCheckInModal, setQuickCheckInModal] = useState({
+    isOpen: false,
+    entry: null,
+    activityId: '',
+    checkInTime: '',
+    reason: '',
+    loading: false,
+    error: null
+  });
 
   // Force checkout modal state
   const [forceCheckoutModal, setForceCheckoutModal] = useState({
@@ -236,6 +247,38 @@ export default function DailyReview() {
     return activity?.endTime || currentEvent?.typicalEndTime || '15:00';
   };
 
+  const getLocalDateTimeValue = (dateString, timeString) => {
+    const [hours = '09', mins = '00'] = (timeString || '09:00').split(':');
+    const [yr, mo, dy] = dateString.split('-').map(Number);
+    const date = new Date(yr, mo - 1, dy);
+    date.setHours(parseInt(hours), parseInt(mins), 0, 0);
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hh = String(date.getHours()).padStart(2, '0');
+    const mm = String(date.getMinutes()).padStart(2, '0');
+    return `${year}-${month}-${day}T${hh}:${mm}`;
+  };
+
+  const getDefaultActivity = () => currentEvent?.activities?.[0] || null;
+
+  // Open quick check-in modal
+  const openQuickCheckInModal = (entry) => {
+    const defaultActivity = getDefaultActivity();
+    const startTime = defaultActivity?.startTime || currentEvent?.typicalStartTime || '09:00';
+
+    setQuickCheckInModal({
+      isOpen: true,
+      entry,
+      activityId: defaultActivity?.id || '',
+      checkInTime: getLocalDateTimeValue(selectedDate, startTime),
+      reason: '',
+      loading: false,
+      error: null
+    });
+  };
+
   // Open force checkout modal
   const openForceCheckoutModal = (entry) => {
     // Default to activity end time
@@ -353,6 +396,47 @@ export default function DailyReview() {
         ...prev,
         loading: false,
         error: error.message || 'Failed to force checkout'
+      }));
+    }
+  };
+
+  // Handle quick check-in
+  const handleQuickCheckIn = async () => {
+    if (!quickCheckInModal.entry || !quickCheckInModal.activityId || !quickCheckInModal.checkInTime) {
+      setQuickCheckInModal(prev => ({ ...prev, error: 'Activity and check-in time are required' }));
+      return;
+    }
+
+    setQuickCheckInModal(prev => ({ ...prev, loading: true, error: null }));
+
+    try {
+      const quickCheckInFunc = httpsCallable(functions, 'quickCheckIn');
+      const result = await quickCheckInFunc({
+        studentId: quickCheckInModal.entry.studentId,
+        eventId: currentEvent.id,
+        activityId: quickCheckInModal.activityId,
+        date: selectedDate,
+        checkInTime: new Date(quickCheckInModal.checkInTime).toISOString(),
+        reason: quickCheckInModal.reason
+      });
+
+      if (result.data.success) {
+        setQuickCheckInModal({
+          isOpen: false,
+          entry: null,
+          activityId: '',
+          checkInTime: '',
+          reason: '',
+          loading: false,
+          error: null
+        });
+      }
+    } catch (error) {
+      console.error('Quick check-in error:', error);
+      setQuickCheckInModal(prev => ({
+        ...prev,
+        loading: false,
+        error: error.message || 'Failed to check in student'
       }));
     }
   };
@@ -912,7 +996,14 @@ export default function DailyReview() {
                     <td className="px-4 py-3">
                       <div className="flex flex-wrap gap-2">
                         {entry.isNoCheckIn ? (
-                          <span className="text-sm text-gray-500">No entry</span>
+                          <Button
+                            size="sm"
+                            variant="success"
+                            onClick={() => openQuickCheckInModal(entry)}
+                            aria-label={`Check in ${entry.student.firstName} ${entry.student.lastName}`}
+                          >
+                            Check In
+                          </Button>
                         ) : entry.isVoided ? (
                           <Button
                             size="sm"
@@ -945,9 +1036,9 @@ export default function DailyReview() {
                                 size="sm"
                                 variant="danger"
                                 onClick={() => openForceCheckoutModal(entry)}
-                                aria-label={`Force checkout for ${entry.student.firstName} ${entry.student.lastName}`}
+                                aria-label={`Checkout for ${entry.student.firstName} ${entry.student.lastName}`}
                               >
-                                Force Out
+                                Checkout
                               </Button>
                             )}
                           </>
@@ -984,6 +1075,7 @@ export default function DailyReview() {
                   getStatusDisplay={getStatusDisplay}
                   getStatusClass={getStatusClass}
                   onEdit={openEditModal}
+                  onQuickCheckIn={openQuickCheckInModal}
                   onForceCheckout={openForceCheckoutModal}
                   onVoid={openVoidModal}
                   onRestore={handleRestoreEntry}
@@ -1022,11 +1114,117 @@ export default function DailyReview() {
         </div>
       </div>
 
+      {/* Quick Check-In Modal */}
+      <Modal
+        isOpen={quickCheckInModal.isOpen}
+        onClose={() => setQuickCheckInModal({ ...quickCheckInModal, isOpen: false })}
+        title="Check In"
+        size="md"
+        footer={
+          <>
+            <Button
+              variant="secondary"
+              onClick={() => setQuickCheckInModal({ ...quickCheckInModal, isOpen: false })}
+              disabled={quickCheckInModal.loading}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="success"
+              onClick={handleQuickCheckIn}
+              loading={quickCheckInModal.loading}
+            >
+              Check In
+            </Button>
+          </>
+        }
+      >
+        {quickCheckInModal.entry && (
+          <div className="space-y-4">
+            <div>
+              <p className="text-gray-600">
+                Check in:{' '}
+                <span className="font-bold text-gray-900">
+                  {quickCheckInModal.entry.student?.firstName} {quickCheckInModal.entry.student?.lastName}
+                </span>
+              </p>
+              <p className="text-sm text-gray-500 mt-1">
+                Date: {formatDate(selectedDate)}
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Activity <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={quickCheckInModal.activityId}
+                onChange={(e) => {
+                  const activity = activityMap[e.target.value];
+                  setQuickCheckInModal(prev => ({
+                    ...prev,
+                    activityId: e.target.value,
+                    checkInTime: getLocalDateTimeValue(
+                      selectedDate,
+                      activity?.startTime || currentEvent?.typicalStartTime || '09:00'
+                    )
+                  }));
+                }}
+                className="input-field w-full"
+              >
+                <option value="">Select activity</option>
+                {(currentEvent?.activities || []).map(activity => (
+                  <option key={activity.id} value={activity.id}>
+                    {activity.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Check-In Time <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="datetime-local"
+                value={quickCheckInModal.checkInTime}
+                onChange={(e) => setQuickCheckInModal(prev => ({
+                  ...prev,
+                  checkInTime: e.target.value
+                }))}
+                className="input-field w-full"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Reason or Note
+              </label>
+              <textarea
+                value={quickCheckInModal.reason}
+                onChange={(e) => setQuickCheckInModal(prev => ({
+                  ...prev,
+                  reason: e.target.value
+                }))}
+                placeholder="e.g., Missed scan-in, entered from roster review"
+                className="input-field w-full h-24 resize-none"
+              />
+            </div>
+
+            {quickCheckInModal.error && (
+              <div className="text-red-600 text-sm">
+                {quickCheckInModal.error}
+              </div>
+            )}
+          </div>
+        )}
+      </Modal>
+
       {/* Force Checkout Modal */}
       <Modal
         isOpen={forceCheckoutModal.isOpen}
         onClose={() => setForceCheckoutModal({ ...forceCheckoutModal, isOpen: false })}
-        title="Force Check-Out"
+        title="Checkout"
         size="md"
         footer={
           <>
@@ -1042,7 +1240,7 @@ export default function DailyReview() {
               onClick={handleForceCheckout}
               loading={forceCheckoutModal.loading}
             >
-              Force Check-Out
+              Checkout
             </Button>
           </>
         }
@@ -1051,7 +1249,7 @@ export default function DailyReview() {
           <div className="space-y-4">
             <div>
               <p className="text-gray-600">
-                Force checkout for:{' '}
+                Checkout:{' '}
                 <span className="font-bold text-gray-900">
                   {forceCheckoutModal.entry.student?.firstName} {forceCheckoutModal.entry.student?.lastName}
                 </span>
@@ -1084,7 +1282,7 @@ export default function DailyReview() {
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Reason for Force Checkout <span className="text-red-500">*</span>
+                Reason for Checkout <span className="text-red-500">*</span>
               </label>
               <textarea
                 value={forceCheckoutModal.reason}

--- a/frontend/src/pages/EventStudentsPage.jsx
+++ b/frontend/src/pages/EventStudentsPage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { printInNewWindow, createPrintDocument } from '../utils/printUtils';
-import { db } from '../utils/firebase';
+import { db, storage } from '../utils/firebase';
 import {
     collection,
     onSnapshot,
@@ -13,12 +13,52 @@ import {
     where,
     serverTimestamp,
 } from 'firebase/firestore';
+import { ref, getDownloadURL } from 'firebase/storage';
+import { generateFilledPdf, mergePdfs, openPdfForPrinting } from '../utils/pdfTemplateUtils';
 import { useAuth } from '../contexts/AuthContext';
 import { useEvent } from '../contexts/EventContext';
 import Button from '../components/common/Button';
 import Spinner from '../components/common/Spinner';
 import PrintableBadge from '../components/common/PrintableBadge';
 import { GRADE_LEVEL_OPTIONS } from '../utils/grades';
+
+const normalizeTemplateText = (value = '') =>
+    value.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+const SCHOOL_TEMPLATE_ALIASES = [
+    { school: ['bishopmoore', 'bishopmoorecatholic'], template: ['bishopmoore'] },
+    { school: ['thefirstacademy', 'firstacademy', 'tfa'], template: ['thefirstacademy', 'firstacademy', 'tfa'] },
+];
+
+const findTemplateForSchool = (schoolName, templates) => {
+    const normalizedSchool = normalizeTemplateText(schoolName);
+    if (!normalizedSchool) return null;
+
+    const templateMatches = (template, values) => {
+        const normalizedTemplate = normalizeTemplateText(`${template.name || ''} ${template.fileName || ''}`);
+        return values.some(value => normalizedTemplate.includes(value));
+    };
+
+    const exactMatch = templates.find(template => {
+        const normalizedTemplate = normalizeTemplateText(`${template.name || ''} ${template.fileName || ''}`);
+        return normalizedTemplate &&
+            (normalizedTemplate.includes(normalizedSchool) || normalizedSchool.includes(normalizedTemplate));
+    });
+    if (exactMatch) return exactMatch;
+
+    const alias = SCHOOL_TEMPLATE_ALIASES.find(item =>
+        item.school.some(value => normalizedSchool.includes(value))
+    );
+    if (alias) {
+        const aliasMatch = templates.find(template => templateMatches(template, alias.template));
+        if (aliasMatch) return aliasMatch;
+    }
+
+    const ocpsTemplate = templates.find(template => templateMatches(template, ['ocps']));
+    if (ocpsTemplate) return ocpsTemplate;
+
+    return null;
+};
 
 export default function EventStudentsPage() {
     const { eventId: paramEventId } = useParams();
@@ -37,17 +77,33 @@ export default function EventStudentsPage() {
     const [loading, setLoading] = useState(true);
     const [printingReports, setPrintingReports] = useState(false);
     const [removingStudentId, setRemovingStudentId] = useState(null);
+    const [selectedStudents, setSelectedStudents] = useState(new Set());
+    const [pdfTemplates, setPdfTemplates] = useState([]);
+    const [defaultTemplateId, setDefaultTemplateId] = useState(null);
 
     const [searchTerm, setSearchTerm] = useState('');
 
     const [addStudentModal, setAddStudentModal] = useState(false);
-    const [addForm, setAddForm] = useState({ firstName: '', lastName: '', schoolName: '', gradeLevel: '', gradYear: '' });
+    const [addForm, setAddForm] = useState({ firstName: '', lastName: '', schoolName: '', gradeLevel: '', gradYear: '', pdfTemplateId: '' });
     const [addingSaving, setAddingSaving] = useState(false);
 
     const [importModal, setImportModal] = useState(false);
     const [importSearch, setImportSearch] = useState('');
     const [importSelected, setImportSelected] = useState(new Set());
     const [importSaving, setImportSaving] = useState(false);
+
+    useEffect(() => {
+        const unsubTemplates = onSnapshot(collection(db, 'pdfTemplates'), snap => {
+            setPdfTemplates(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+        });
+        const unsubDefaults = onSnapshot(doc(db, 'settings', 'pdfDefaults'), snap => {
+            setDefaultTemplateId(snap.exists() ? snap.data().defaultTemplateId : null);
+        });
+        return () => {
+            unsubTemplates();
+            unsubDefaults();
+        };
+    }, []);
 
     // Load event — use context if available (Operations nav), otherwise fetch from Firestore
     useEffect(() => {
@@ -121,6 +177,39 @@ export default function EventStudentsPage() {
         );
     }, [eventStudents, searchTerm]);
 
+    const allFilteredSelected = filteredStudents.length > 0 &&
+        filteredStudents.every(s => selectedStudents.has(s.id));
+
+    const getStudentsToPrint = () => {
+        if (selectedStudents.size > 0) {
+            return eventStudents.filter(s => selectedStudents.has(s.id));
+        }
+        return filteredStudents;
+    };
+
+    const toggleStudentSelection = (studentId) => {
+        setSelectedStudents(prev => {
+            const next = new Set(prev);
+            next.has(studentId) ? next.delete(studentId) : next.add(studentId);
+            return next;
+        });
+    };
+
+    const selectAllFiltered = () => {
+        setSelectedStudents(prev => {
+            const next = new Set(prev);
+            filteredStudents.forEach(s => next.add(s.id));
+            return next;
+        });
+    };
+
+    const clearSelection = () => {
+        setSelectedStudents(new Set());
+    };
+
+    const selectedPrintCount = eventStudents.filter(s => selectedStudents.has(s.id)).length;
+    const printStudentCount = selectedStudents.size > 0 ? selectedPrintCount : filteredStudents.length;
+
     // Students not yet associated with this event (for import modal)
     const importableStudents = useMemo(() => {
         return allStudents
@@ -150,10 +239,10 @@ export default function EventStudentsPage() {
         e.preventDefault();
         setAddingSaving(true);
         try {
+            const studentData = { ...addForm, overrideHours: 0, createdAt: serverTimestamp() };
+            if (!studentData.pdfTemplateId) delete studentData.pdfTemplateId;
             const docRef = await addDoc(collection(db, 'students'), {
-                ...addForm,
-                overrideHours: 0,
-                createdAt: serverTimestamp(),
+                ...studentData,
             });
             await addDoc(collection(db, 'eventStudents'), {
                 eventId,
@@ -162,7 +251,7 @@ export default function EventStudentsPage() {
                 addedBy: user?.uid || 'admin',
             });
             setAddStudentModal(false);
-            setAddForm({ firstName: '', lastName: '', schoolName: '', gradeLevel: '', gradYear: '' });
+            setAddForm({ firstName: '', lastName: '', schoolName: '', gradeLevel: '', gradYear: '', pdfTemplateId: '' });
         } catch (err) {
             console.error('Error adding student:', err);
         } finally {
@@ -212,13 +301,6 @@ export default function EventStudentsPage() {
         .badge-name { font-size: 14pt; font-weight: bold; margin-bottom: 4px; color: #000; }
         .badge-id { font-size: 9pt; color: #666; margin-bottom: 8px; }
         .badge-qr { margin: 0 auto; }
-        .ocps-form-container { font-family: Arial, sans-serif; padding: 0.25in; color: black; line-height: 1.05; font-size: 8.5pt; page-break-after: always; height: 100vh; box-sizing: border-box; }
-        table { border-collapse: collapse; width: 100%; margin-bottom: 2px; }
-        th, td { border: 1px solid black; padding: 2px 6px; vertical-align: middle; }
-        .field-box { border-bottom: 1px solid black; display: inline-block; min-width: 120px; padding: 0 5px; font-weight: bold; }
-        .reflection-box { border: 1px solid black; height: 165px; width: 100%; margin-top: 2px; display: flex; flex-direction: column; }
-        .reflection-line { border-bottom: 1px solid #ddd; flex: 1; }
-        .ocps-logo { width: 40px; height: 40px; border: 1px solid black; display: flex; align-items: center; justify-content: center; font-weight: bold; font-size: 7pt; text-align: center; }
     `;
 
     const getStudentActivityLog = (studentId) => {
@@ -253,10 +335,22 @@ export default function EventStudentsPage() {
         }).filter(Boolean);
     };
 
+    const getEffectiveTemplate = (student) => {
+        if (student.pdfTemplateId) {
+            return pdfTemplates.find(template => template.id === student.pdfTemplateId) || null;
+        }
+
+        const schoolTemplate = findTemplateForSchool(student.schoolName, pdfTemplates);
+        if (schoolTemplate) return schoolTemplate;
+
+        return defaultTemplateId ? pdfTemplates.find(template => template.id === defaultTemplateId) || null : null;
+    };
+
     const handlePrintBadges = () => {
+        const studentsToPrint = getStudentsToPrint();
         const pages = [];
-        for (let i = 0; i < filteredStudents.length; i += 8) {
-            pages.push(filteredStudents.slice(i, i + 8));
+        for (let i = 0; i < studentsToPrint.length; i += 8) {
+            pages.push(studentsToPrint.slice(i, i + 8));
         }
 
         const body = pages.map((pageStudents, pageIndex) => (
@@ -274,84 +368,61 @@ export default function EventStudentsPage() {
         printInNewWindow(html);
     };
 
-    const buildStudentFormHtml = (student, activityLog, grandTotal) => {
-        const orgName = event?.organizationName || '';
-        const contactName = event?.contactName || '---';
-        const activityRows = activityLog.map(activity => `
-            <tr>
-                <td>${orgName} ${activity.name || ''}</td>
-                <td style="text-align:center">${activity.dateDisplay}</td>
-                <td>${contactName}</td>
-                <td></td>
-                <td style="font-weight:bold">${activity.totalHours}</td>
-            </tr>
-        `).join('');
-        const blankRows = Array.from({ length: Math.max(0, 10 - activityLog.length) })
-            .map(() => '<tr style="height:36px"><td></td><td></td><td></td><td></td><td></td></tr>')
-            .join('');
+    const handlePrintReports = async () => {
+        const studentsToPrint = getStudentsToPrint();
+        const pdfGroup = [];
+        const missingTemplateStudents = [];
 
-        return `<div class="ocps-form-container">
-            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;border-bottom:2px solid black;padding-bottom:4px">
-                <div class="ocps-logo">OCPS</div>
-                <h1 style="font-size:13pt;font-weight:bold;text-align:center;flex:1">Community/Work Service Log and Reflection</h1>
-            </div>
-            <table style="margin-bottom:4px"><tbody>
-                <tr>
-                    <td style="width:33%;border:none">Student ID #: <span class="field-box" style="min-width:100px"></span></td>
-                    <td style="border:none">Student Name: <span class="field-box" style="min-width:220px">${student.firstName} ${student.lastName}</span></td>
-                </tr>
-                <tr>
-                    <td style="border:none">School Name: <span class="field-box" style="min-width:200px">${student.schoolName || ''}</span></td>
-                    <td style="border:none;text-align:right">Graduation Year: <span class="field-box" style="min-width:80px">${student.gradYear || '____'}</span></td>
-                </tr>
-            </tbody></table>
-            <p style="font-size:7.5pt;margin:2px 0">Social/Civic Issue/Professional Area Addressing with Service Activity Log (Optional):</p>
-            <div style="border-bottom:1px solid black;width:100%;margin-bottom:4px;height:16px"></div>
-            <p style="font-weight:bold;font-size:8pt;margin:2px 0">Description of Volunteer/Paid Work Activity:</p>
-            <div style="border-bottom:1px solid black;width:100%;margin-bottom:8px;height:16px"></div>
-            <table style="margin-bottom:8px;text-align:center"><thead>
-                <tr style="background:#f3f4f6;font-size:8pt">
-                    <th style="width:20%">Service Organization/Business</th>
-                    <th style="width:30%">Date(s) of Service Activity/Work</th>
-                    <th style="width:15%">Contact Name</th>
-                    <th style="width:20%">Signature of Contact</th>
-                    <th style="width:15%">Hours Completed</th>
-                </tr>
-            </thead><tbody>
-                ${activityRows}${blankRows}
-                <tr>
-                    <td colspan="4" style="text-align:right;font-weight:bold;text-transform:uppercase">Total:</td>
-                    <td style="font-weight:bold;background:#f9fafb">${grandTotal.toFixed(2)}</td>
-                </tr>
-            </tbody></table>
-            <div style="margin-top:4px">
-                <p style="font-weight:bold;font-size:7.5pt;margin:0">Reflection on Service Activity/Work (attach additional pages if necessary):</p>
-                <p style="font-size:6.5pt;font-style:italic;margin:2px 0">Attach a copy of your pay stub for work hours if applicable. Complete the reflection below...</p>
-                <div class="reflection-box">${Array.from({ length: 7 }).map(() => '<div class="reflection-line"></div>').join('')}</div>
-            </div>
-            <p style="font-size:7pt;margin-top:8px;font-weight:bold;line-height:1.3">By signing below, I certify that all information on this document is true and correct. I understand that if I am found to have given false testimony about these hours that the hours will be revoked and endanger my eligibility for the Bright Futures Scholarship.</p>
-            <div style="margin-top:12px;display:flex;justify-content:space-between">
-                <div style="font-size:8pt">Student Signature: _______________________ Date: ________</div>
-                <div style="font-size:8pt">Parent Signature: ________________________ Date: ________</div>
-            </div>
-            <p style="font-size:5.5pt;margin-top:4px;color:#9ca3af">Revised 8/2023</p>
-        </div>`;
-    };
+        studentsToPrint.forEach(student => {
+            const template = getEffectiveTemplate(student);
+            if (template) {
+                pdfGroup.push({ student, template });
+            } else {
+                missingTemplateStudents.push(student);
+            }
+        });
 
-    const handlePrintReports = () => {
-        setPrintingReports(true);
-        try {
-            const formsHtml = filteredStudents.map(student => {
-                const activityLog = getStudentActivityLog(student.id);
-                const totalCalc = activityLog.reduce((sum, activity) => sum + parseFloat(activity.totalHours), 0);
-                const grandTotal = totalCalc + parseFloat(student.overrideHours || 0);
-                return buildStudentFormHtml(student, activityLog, grandTotal);
-            }).join('');
+        if (missingTemplateStudents.length > 0) {
+            const names = missingTemplateStudents
+                .map(student => `${student.firstName} ${student.lastName}`.trim())
+                .join(', ');
+            alert(`Cannot print reports until every student has a PDF template. Missing template for: ${names}`);
+            return;
+        }
 
-            const html = createPrintDocument({ title: `${event?.name || 'Event'} Service Logs`, styles: PRINT_STYLES, body: formsHtml });
-            printInNewWindow(html);
-        } finally {
-            setPrintingReports(false);
+        if (pdfGroup.length > 0) {
+            setPrintingReports(true);
+            try {
+                const allPdfBytes = [];
+                for (const { student, template } of pdfGroup) {
+                    const storageRef = ref(storage, template.storagePath);
+                    const url = await getDownloadURL(storageRef);
+                    const response = await fetch(url);
+                    const templateBytes = await response.arrayBuffer();
+
+                    const activityLog = getStudentActivityLog(student.id);
+                    const totalCalc = activityLog.reduce((sum, activity) => sum + parseFloat(activity.totalHours), 0);
+                    const grandTotal = totalCalc + parseFloat(student.overrideHours || 0);
+
+                    const pdfBytes = await generateFilledPdf(templateBytes, template.fields, {
+                        student,
+                        totalHours: grandTotal,
+                        eventName: event?.name || '',
+                        activityLog,
+                        event,
+                        timeEntries: eventEntries.filter(entry => entry.studentId === student.id && !entry.isVoided),
+                    });
+                    allPdfBytes.push(pdfBytes);
+                }
+
+                const mergedBytes = await mergePdfs(allPdfBytes);
+                openPdfForPrinting(mergedBytes, `${event?.name || 'event'}-service-logs.pdf`);
+            } catch (err) {
+                console.error('Event PDF generation failed:', err);
+                alert('Failed to generate PDFs: ' + err.message);
+            } finally {
+                setPrintingReports(false);
+            }
         }
     };
 
@@ -397,16 +468,16 @@ export default function EventStudentsPage() {
                         aria-label="Search students"
                     />
                     <div className="flex flex-wrap gap-2 shrink-0">
-                        <Button variant="secondary" onClick={handlePrintBadges} disabled={filteredStudents.length === 0}>
-                            Print Badges
+                        <Button variant="secondary" onClick={handlePrintBadges} disabled={printStudentCount === 0}>
+                            {selectedStudents.size > 0 ? `Print Badges (${selectedPrintCount})` : 'Print Badges'}
                         </Button>
                         <Button
                             variant="secondary"
                             onClick={handlePrintReports}
-                            disabled={filteredStudents.length === 0 || printingReports}
+                            disabled={printStudentCount === 0 || printingReports}
                             loading={printingReports}
                         >
-                            {printingReports ? 'Generating...' : 'Print Reports'}
+                            {printingReports ? 'Generating...' : selectedStudents.size > 0 ? `Print Reports (${selectedPrintCount})` : 'Print Reports'}
                         </Button>
                         {allStudents.length > eventStudents.length && (
                             <Button
@@ -423,6 +494,27 @@ export default function EventStudentsPage() {
                 </div>
             </div>
 
+            {selectedStudents.size > 0 && (
+                <div className="bg-primary-50 border border-primary-200 rounded-xl px-4 py-3 mb-4 flex flex-wrap items-center justify-between gap-3">
+                    <div className="flex items-center gap-3">
+                        <span className="inline-flex items-center justify-center bg-primary-600 text-white text-sm font-bold px-3 py-1 rounded-full">
+                            {selectedStudents.size}
+                        </span>
+                        <span className="text-sm font-medium text-primary-800">
+                            {selectedStudents.size === 1 ? 'student selected' : 'students selected'}
+                        </span>
+                    </div>
+                    <div className="flex gap-2">
+                        <Button onClick={selectAllFiltered} variant="secondary" size="sm">
+                            Select All Visible ({filteredStudents.length})
+                        </Button>
+                        <Button onClick={clearSelection} variant="secondary" size="sm">
+                            Clear Selection
+                        </Button>
+                    </div>
+                </div>
+            )}
+
             {/* Student list */}
             {eventStudents.length === 0 ? (
                 <div className="bg-white rounded-2xl shadow-sm border p-12 text-center text-gray-400">
@@ -434,6 +526,25 @@ export default function EventStudentsPage() {
                     <table className="min-w-full divide-y divide-gray-200">
                         <thead className="bg-gray-50">
                             <tr className="text-left text-xs font-bold text-gray-400 uppercase tracking-wider">
+                                <th className="px-4 py-4 w-12">
+                                    <input
+                                        type="checkbox"
+                                        checked={allFilteredSelected}
+                                        onChange={e => {
+                                            if (e.target.checked) {
+                                                selectAllFiltered();
+                                            } else {
+                                                setSelectedStudents(prev => {
+                                                    const next = new Set(prev);
+                                                    filteredStudents.forEach(s => next.delete(s.id));
+                                                    return next;
+                                                });
+                                            }
+                                        }}
+                                        className="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500 cursor-pointer"
+                                        aria-label={allFilteredSelected ? 'Deselect all students' : 'Select all students'}
+                                    />
+                                </th>
                                 <th className="px-6 py-4">Name</th>
                                 <th className="px-6 py-4">School</th>
                                 <th className="px-6 py-4">Grade</th>
@@ -445,13 +556,22 @@ export default function EventStudentsPage() {
                         <tbody className="divide-y divide-gray-100">
                             {filteredStudents.length === 0 ? (
                                 <tr>
-                                    <td colSpan={6} className="px-6 py-12 text-center text-gray-400">
+                                    <td colSpan={7} className="px-6 py-12 text-center text-gray-400">
                                         <p className="font-bold">No students match your search</p>
                                         <p className="text-sm mt-1">Try a different name.</p>
                                     </td>
                                 </tr>
                             ) : filteredStudents.map(s => (
-                                <tr key={s.id} className="hover:bg-gray-50 transition-colors">
+                                <tr key={s.id} className={`hover:bg-gray-50 transition-colors ${selectedStudents.has(s.id) ? 'bg-primary-50' : ''}`}>
+                                    <td className="px-4 py-4">
+                                        <input
+                                            type="checkbox"
+                                            checked={selectedStudents.has(s.id)}
+                                            onChange={() => toggleStudentSelection(s.id)}
+                                            className="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500 cursor-pointer"
+                                            aria-label={`Select ${s.firstName} ${s.lastName}`}
+                                        />
+                                    </td>
                                     <td className="px-6 py-4 font-bold text-gray-900">
                                         {s.firstName} {s.lastName}
                                     </td>
@@ -558,6 +678,23 @@ export default function EventStudentsPage() {
                                         placeholder="e.g. 2027"
                                     />
                                 </div>
+                            </div>
+                            <div>
+                                <label className="block text-[10px] font-black text-gray-400 uppercase mb-1">PDF Template</label>
+                                <select
+                                    className="w-full border border-gray-200 rounded-xl p-3 focus:ring-2 focus:ring-primary-500 outline-none"
+                                    value={addForm.pdfTemplateId}
+                                    onChange={e => setAddForm(f => ({ ...f, pdfTemplateId: e.target.value }))}
+                                >
+                                    <option value="">
+                                        {defaultTemplateId
+                                            ? `Default: ${pdfTemplates.find(t => t.id === defaultTemplateId)?.name || 'Default'}`
+                                            : 'Use default template'}
+                                    </option>
+                                    {pdfTemplates.map(template => (
+                                        <option key={template.id} value={template.id}>{template.name}</option>
+                                    ))}
+                                </select>
                             </div>
                             <div className="flex gap-3 pt-4">
                                 <Button type="submit" className="flex-1" disabled={addingSaving} loading={addingSaving}>

--- a/frontend/src/pages/EventStudentsPage.test.jsx
+++ b/frontend/src/pages/EventStudentsPage.test.jsx
@@ -4,34 +4,72 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import EventStudentsPage from './EventStudentsPage';
 
-vi.mock('../utils/firebase', () => ({ db: {} }));
+vi.mock('../utils/firebase', () => ({ db: {}, storage: {} }));
+
+vi.mock('firebase/storage', () => ({
+    ref: vi.fn(),
+    getDownloadURL: vi.fn(() => Promise.resolve('https://storage.example.com/template.pdf')),
+}));
+
+vi.mock('../utils/pdfTemplateUtils', () => ({
+    generateFilledPdf: vi.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
+    mergePdfs: vi.fn((arr) => Promise.resolve(arr[0] || new Uint8Array([1, 2, 3]))),
+    openPdfForPrinting: vi.fn(),
+}));
+
+vi.mock('../utils/printUtils', () => ({
+    printInNewWindow: vi.fn(),
+    createPrintDocument: vi.fn(({ title, styles, body }) =>
+        `<!DOCTYPE html><html><head><title>${title}</title><style>${styles}</style></head><body>${body}</body></html>`
+    ),
+}));
 
 const mockStudents = [
-    { id: 'student1', firstName: 'Alice', lastName: 'Adams', schoolName: 'Central High', gradeLevel: '10', gradYear: '2027' },
+    { id: 'student1', firstName: 'Alice', lastName: 'Adams', schoolName: 'Central High', gradeLevel: '10', gradYear: '2027', pdfTemplateId: 'template1' },
     { id: 'student2', firstName: 'Bob', lastName: 'Brown', schoolName: 'West High', gradeLevel: '11', gradYear: '2026' },
     { id: 'student3', firstName: 'Charlie', lastName: 'Clark', schoolName: 'East High', gradeLevel: '12', gradYear: '2025' },
 ];
 
 const mockEvents = [
-    { id: 'event123', name: 'VBS 2026', organizationName: 'Church' },
+    {
+        id: 'event123',
+        name: 'VBS 2026',
+        organizationName: 'Church',
+        contactName: 'Coordinator',
+        activities: [{ id: 'activity1', name: 'Setup' }],
+    },
 ];
 
 const mockCurrentEvent = { id: 'event123', name: 'VBS 2026' };
+const defaultPdfTemplates = [
+    { id: 'template1', name: 'Central High Form', storagePath: 'templates/central.pdf', fields: [] },
+    { id: 'template2', name: 'OCPS', fileName: 'ocps.pdf', storagePath: 'templates/ocps.pdf', fields: [] },
+];
 
 let onSnapshotCalls = [];
 let addDocMock;
+let mockPdfTemplates = [...defaultPdfTemplates];
 
 vi.mock('firebase/firestore', () => ({
     collection: vi.fn((db, path) => ({ _collPath: path })),
-    doc: vi.fn((db, col, id) => ({ _docPath: `${col}/${id}` })),
+    doc: vi.fn((db, col, id) => ({ _isDoc: true, _docPath: `${col}/${id}` })),
     query: vi.fn((ref) => ref),
     where: vi.fn(() => ({})),
     deleteDoc: vi.fn().mockResolvedValue(undefined),
     onSnapshot: vi.fn((queryOrRef, callback) => {
+        if (queryOrRef?._isDoc) {
+            queueMicrotask(() => callback({ exists: () => false, data: () => null }));
+            const unsub = vi.fn();
+            onSnapshotCalls.push(unsub);
+            return unsub;
+        }
+
         const path = queryOrRef?._collPath;
 
         if (path === 'events') {
             queueMicrotask(() => callback({ docs: mockEvents.map(e => ({ id: e.id, data: () => e })) }));
+        } else if (path === 'pdfTemplates') {
+            queueMicrotask(() => callback({ docs: mockPdfTemplates.map(template => ({ id: template.id, data: () => template })) }));
         } else if (path === 'students') {
             queueMicrotask(() => callback({ docs: mockStudents.map(s => ({ id: s.id, data: () => s })) }));
         } else if (path === 'eventStudents') {
@@ -40,7 +78,17 @@ vi.mock('firebase/firestore', () => ({
         } else if (path === 'timeEntries') {
             // student2 checked in via time entries
             queueMicrotask(() => callback({ docs: [
-                { id: 'te1', data: () => ({ eventId: 'event123', studentId: 'student2', isVoided: false }) }
+                {
+                    id: 'te1',
+                    data: () => ({
+                        eventId: 'event123',
+                        studentId: 'student2',
+                        activityId: 'activity1',
+                        isVoided: false,
+                        checkInTime: { seconds: 1704096000, toDate: () => new Date('2024-01-01T08:00:00') },
+                        checkOutTime: { seconds: 1704110400, toDate: () => new Date('2024-01-01T12:00:00') },
+                    })
+                }
             ] }));
         } else {
             queueMicrotask(() => callback({ docs: [] }));
@@ -76,6 +124,11 @@ describe('EventStudentsPage', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         onSnapshotCalls = [];
+        mockPdfTemplates = [...defaultPdfTemplates];
+        window.alert = vi.fn();
+        global.fetch = vi.fn(() => Promise.resolve({
+            arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+        }));
     });
 
     it('renders page heading with event name', async () => {
@@ -135,6 +188,84 @@ describe('EventStudentsPage', () => {
         });
     });
 
+    it('supports selecting visible event students for targeted printing', async () => {
+        const user = userEvent.setup();
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+
+        await user.click(screen.getByRole('checkbox', { name: /Select Alice Adams/i }));
+
+        expect(screen.getByText(/student selected/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Print Badges \(1\)/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Print Reports \(1\)/i })).toBeInTheDocument();
+    });
+
+    it('prints only selected badges when students are selected', async () => {
+        const { printInNewWindow } = await import('../utils/printUtils');
+        const user = userEvent.setup();
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+
+        await user.click(screen.getByRole('checkbox', { name: /Select Alice Adams/i }));
+        await user.click(screen.getByRole('button', { name: /Print Badges \(1\)/i }));
+
+        expect(printInNewWindow).toHaveBeenCalledTimes(1);
+        const printedHtml = printInNewWindow.mock.calls[0][0];
+        expect(printedHtml).toContain('Alice Adams');
+        expect(printedHtml).not.toContain('Bob Brown');
+    });
+
+    it('uses the selected student PDF template for event report printing', async () => {
+        const { generateFilledPdf, openPdfForPrinting } = await import('../utils/pdfTemplateUtils');
+        const user = userEvent.setup();
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+
+        await user.click(screen.getByRole('checkbox', { name: /Select Alice Adams/i }));
+        await user.click(screen.getByRole('button', { name: /Print Reports \(1\)/i }));
+
+        await waitFor(() => {
+            expect(generateFilledPdf).toHaveBeenCalledTimes(1);
+            expect(openPdfForPrinting).toHaveBeenCalledTimes(1);
+        });
+        expect(generateFilledPdf.mock.calls[0][2].student.id).toBe('student1');
+    });
+
+    it('uses a school-matched PDF template for students without an explicit template', async () => {
+        const { generateFilledPdf, openPdfForPrinting } = await import('../utils/pdfTemplateUtils');
+        const { printInNewWindow } = await import('../utils/printUtils');
+        const user = userEvent.setup();
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Bob Brown')).toBeInTheDocument());
+
+        await user.click(screen.getByRole('checkbox', { name: /Select Bob Brown/i }));
+        await user.click(screen.getByRole('button', { name: /Print Reports \(1\)/i }));
+
+        await waitFor(() => {
+            expect(generateFilledPdf).toHaveBeenCalledTimes(1);
+            expect(openPdfForPrinting).toHaveBeenCalledTimes(1);
+        });
+        expect(generateFilledPdf.mock.calls[0][2].student.id).toBe('student2');
+        expect(printInNewWindow).not.toHaveBeenCalled();
+    });
+
+    it('does not fall back to the old HTML report when a PDF template is missing', async () => {
+        mockPdfTemplates = [];
+        const { generateFilledPdf, openPdfForPrinting } = await import('../utils/pdfTemplateUtils');
+        const { printInNewWindow } = await import('../utils/printUtils');
+        const user = userEvent.setup();
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+
+        await user.click(screen.getByRole('checkbox', { name: /Select Alice Adams/i }));
+        await user.click(screen.getByRole('button', { name: /Print Reports \(1\)/i }));
+
+        expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('Missing template for: Alice Adams'));
+        expect(generateFilledPdf).not.toHaveBeenCalled();
+        expect(openPdfForPrinting).not.toHaveBeenCalled();
+        expect(printInNewWindow).not.toHaveBeenCalled();
+    });
+
     it('opens Add Student modal on button click', async () => {
         const user = userEvent.setup();
         renderPage();
@@ -148,7 +279,7 @@ describe('EventStudentsPage', () => {
         await waitFor(() => screen.getByRole('button', { name: /\+ Add Student/i }));
         fireEvent.click(screen.getByRole('button', { name: /\+ Add Student/i }));
 
-        const gradeSelect = screen.getByRole('combobox');
+        const gradeSelect = screen.getAllByRole('combobox')[0];
         expect(within(gradeSelect).getByRole('option', { name: 'Kindergarten' })).toHaveValue('K');
         expect(within(gradeSelect).getByRole('option', { name: '12th Grade' })).toHaveValue('12');
     });

--- a/functions/index.js
+++ b/functions/index.js
@@ -19,7 +19,7 @@ export { generateForms } from './src/generateForms.js';
 export { createUser, updateUser, deleteUser, listUsers, resetUserPassword } from './src/userManagement.js';
 
 // Daily Review Functions (PRD Section 3.5.2)
-export { forceCheckOut, forceAllCheckOut, getDailyReviewSummary } from './src/dailyReview.js';
+export { quickCheckIn, forceCheckOut, forceAllCheckOut, getDailyReviewSummary } from './src/dailyReview.js';
 
 // Void/Restore Functions (Soft Delete)
 export { voidTimeEntry, restoreTimeEntry } from './src/voidEntry.js';

--- a/functions/src/dailyReview.js
+++ b/functions/src/dailyReview.js
@@ -10,6 +10,143 @@ const toDate = (timestamp) => {
   return new Date(timestamp);
 };
 
+const getFlagsForCheckIn = (checkInTime, typicalStart = '09:00') => {
+  const flags = [];
+  const [hour, min] = typicalStart.split(':');
+  const typical = new Date(checkInTime);
+  typical.setHours(parseInt(hour), parseInt(min), 0, 0);
+
+  if (checkInTime < (typical.getTime() - (15 * 60 * 1000))) {
+    flags.push('early_arrival');
+  }
+
+  return flags;
+};
+
+/**
+ * Quick Check-In Cloud Function
+ * Creates an open time entry from Daily Review for a student who missed scan-in.
+ *
+ * @param {Object} request.data
+ * @param {string} request.data.studentId - Student ID
+ * @param {string} request.data.eventId - Event ID
+ * @param {string} request.data.activityId - Activity ID
+ * @param {string} request.data.date - Date (YYYY-MM-DD)
+ * @param {string} request.data.checkInTime - ISO timestamp for check-in
+ * @param {string} request.data.reason - Optional reason/note
+ */
+export const quickCheckIn = onCall({ cors: true }, async (request) => {
+  const { studentId, eventId, activityId, date, checkInTime, reason } = request.data;
+
+  if (!studentId || !eventId || !activityId || !date || !checkInTime) {
+    throw new HttpsError('invalid-argument', 'Missing required fields: studentId, eventId, activityId, date, and checkInTime');
+  }
+
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'User must be authenticated');
+  }
+
+  const parsedCheckInTime = new Date(checkInTime);
+  if (isNaN(parsedCheckInTime.getTime())) {
+    throw new HttpsError('invalid-argument', 'Invalid check-in time');
+  }
+
+  const checkInDate = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(parsedCheckInTime);
+  if (checkInDate !== date) {
+    throw new HttpsError('invalid-argument', 'Check-in time must match selected date');
+  }
+
+  const db = getFirestore();
+  const userId = request.auth.uid;
+  const userName = request.auth.token?.name || null;
+
+  try {
+    const studentDoc = await db.collection('students').doc(studentId).get();
+    if (!studentDoc.exists) {
+      throw new HttpsError('not-found', 'Student not found');
+    }
+    const student = studentDoc.data();
+
+    const eventDoc = await db.collection('events').doc(eventId).get();
+    if (!eventDoc.exists) {
+      throw new HttpsError('not-found', 'Event not found');
+    }
+    const event = eventDoc.data();
+    const activity = (event.activities || []).find(a => a.id === activityId);
+    if (!activity) {
+      throw new HttpsError('not-found', 'Activity not found for event');
+    }
+
+    const existingQuery = await db.collection('timeEntries')
+      .where('studentId', '==', studentId)
+      .where('eventId', '==', eventId)
+      .where('date', '==', date)
+      .get();
+
+    const hasExistingActiveEntry = existingQuery.docs.some(doc => !doc.data().isVoided);
+    if (hasExistingActiveEntry) {
+      throw new HttpsError('already-exists', 'Student already has a time entry for this date');
+    }
+
+    const checkInTimestamp = Timestamp.fromDate(parsedCheckInTime);
+    const flags = getFlagsForCheckIn(parsedCheckInTime, activity.startTime || event.typicalStartTime || '09:00');
+    const note = reason?.trim();
+    const changeDescription = note
+      ? `Quick Check-In at ${parsedCheckInTime.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}. Reason: ${note}`
+      : `Quick Check-In at ${parsedCheckInTime.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`;
+
+    const entry = {
+      studentId,
+      eventId,
+      activityId,
+      date,
+      checkInTime: checkInTimestamp,
+      checkInBy: userId,
+      checkInByName: userName,
+      checkInMethod: 'daily_review',
+      checkOutTime: null,
+      checkOutBy: null,
+      checkOutMethod: null,
+      hoursWorked: null,
+      rawMinutes: null,
+      reviewStatus: flags.length > 0 ? 'flagged' : 'pending',
+      flags,
+      modifiedBy: userId,
+      modificationReason: changeDescription,
+      modifiedAt: Timestamp.now(),
+      isVoided: false,
+      voidReason: null,
+      voidedAt: null,
+      createdAt: Timestamp.now(),
+      changeLog: [{
+        timestamp: new Date().toISOString(),
+        modifiedBy: userId,
+        type: 'quick_checkin',
+        newCheckInTime: parsedCheckInTime.toISOString(),
+        reason: note || null,
+        description: changeDescription
+      }]
+    };
+
+    const docRef = await db.collection('timeEntries').add(entry);
+
+    return {
+      success: true,
+      entryId: docRef.id,
+      studentName: `${student.firstName} ${student.lastName}`,
+      checkInTime: parsedCheckInTime.toISOString(),
+      flags,
+      message: `Check-in recorded for ${student.firstName} ${student.lastName}`
+    };
+  } catch (error) {
+    console.error('Quick check-in error:', error);
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    throw new HttpsError('internal', error.message);
+  }
+});
+
 /**
  * Force Check-Out Cloud Function
  * Per PRD Section 3.5.2: Daily Review (Nightly)

--- a/functions/test/dailyReview.test.js
+++ b/functions/test/dailyReview.test.js
@@ -58,6 +58,7 @@ const mockCollection = jest.fn();
 const mockDoc = jest.fn();
 const mockWhere = jest.fn();
 const mockGet = jest.fn();
+const mockAdd = jest.fn();
 const mockBatch = jest.fn();
 const mockBatchUpdate = jest.fn();
 const mockBatchCommit = jest.fn().mockResolvedValue(undefined);
@@ -82,6 +83,136 @@ jest.unstable_mockModule('firebase-functions/v2/https', () => ({
     }
   },
 }));
+
+describe('quickCheckIn Cloud Function', () => {
+  let quickCheckIn;
+
+  beforeAll(async () => {
+    const dailyReviewModule = await import('../src/dailyReview.js');
+    quickCheckIn = dailyReviewModule.quickCheckIn;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const queryChain = {
+      where: mockWhere,
+      get: mockGet,
+    };
+
+    mockCollection.mockReturnValue({
+      doc: mockDoc,
+      where: mockWhere,
+      add: mockAdd,
+    });
+    mockDoc.mockReturnValue({ get: mockGet });
+    mockWhere.mockReturnValue(queryChain);
+    mockAdd.mockResolvedValue({ id: 'entry123' });
+  });
+
+  it('should throw error when required fields are missing', async () => {
+    const request = {
+      data: {
+        studentId: 'student123',
+        eventId: 'event123',
+      },
+      auth: { uid: 'admin123' },
+    };
+
+    await expect(quickCheckIn(request)).rejects.toThrow('Missing required fields');
+  });
+
+  it('should throw error when user is not authenticated', async () => {
+    const request = {
+      data: {
+        studentId: 'student123',
+        eventId: 'event123',
+        activityId: 'activity1',
+        date: '2026-06-15',
+        checkInTime: '2026-06-15T09:00:00Z',
+      },
+    };
+
+    await expect(quickCheckIn(request)).rejects.toThrow('User must be authenticated');
+  });
+
+  it('should throw error when check-in time does not match selected date', async () => {
+    const request = {
+      data: {
+        studentId: 'student123',
+        eventId: 'event123',
+        activityId: 'activity1',
+        date: '2026-06-15',
+        checkInTime: '2026-06-16T09:00:00Z',
+      },
+      auth: { uid: 'admin123' },
+    };
+
+    await expect(quickCheckIn(request)).rejects.toThrow('Check-in time must match selected date');
+  });
+
+  it('should create an open time entry', async () => {
+    mockGet
+      .mockResolvedValueOnce(mockStudentDoc)
+      .mockResolvedValueOnce(mockEventDoc)
+      .mockResolvedValueOnce({ docs: [] });
+
+    const request = {
+      data: {
+        studentId: 'student123',
+        eventId: 'event123',
+        activityId: 'activity1',
+        date: '2026-06-15',
+        checkInTime: '2026-06-15T09:00:00Z',
+        reason: 'Missed scan-in',
+      },
+      auth: { uid: 'admin123', token: { name: 'Admin User' } },
+    };
+
+    const result = await quickCheckIn(request);
+
+    expect(result.success).toBe(true);
+    expect(result.entryId).toBe('entry123');
+    expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({
+      studentId: 'student123',
+      eventId: 'event123',
+      activityId: 'activity1',
+      date: '2026-06-15',
+      checkInBy: 'admin123',
+      checkInByName: 'Admin User',
+      checkInMethod: 'daily_review',
+      checkOutTime: null,
+      hoursWorked: null,
+      rawMinutes: null,
+      isVoided: false,
+      modificationReason: expect.stringContaining('Missed scan-in'),
+    }));
+  });
+
+  it('should reject a duplicate active time entry for the date', async () => {
+    mockGet
+      .mockResolvedValueOnce(mockStudentDoc)
+      .mockResolvedValueOnce(mockEventDoc)
+      .mockResolvedValueOnce({
+        docs: [
+          { data: () => ({ isVoided: false }) },
+        ],
+      });
+
+    const request = {
+      data: {
+        studentId: 'student123',
+        eventId: 'event123',
+        activityId: 'activity1',
+        date: '2026-06-15',
+        checkInTime: '2026-06-15T09:00:00Z',
+      },
+      auth: { uid: 'admin123' },
+    };
+
+    await expect(quickCheckIn(request)).rejects.toThrow('Student already has a time entry for this date');
+  });
+});
 
 describe('forceCheckOut Cloud Function', () => {
   let forceCheckOut;


### PR DESCRIPTION
## Summary
- add selection controls to Event Students so badges and reports can target selected/visible students
- route Event Students report printing through PDF templates, including school-name template matching
- remove the old HTML report fallback and alert when a PDF template is missing

Fixes #82

## Tests
- npm test -- EventStudentsPage.test.jsx
- npm run build