### PR TITLE
Fix scanner back to event selection

### DIFF
--- a/frontend/src/components/Scanner/Scanner.test.jsx
+++ b/frontend/src/components/Scanner/Scanner.test.jsx
@@ -216,6 +216,22 @@ describe('Scanner', () => {
       });
     });
 
+    it('should return to event selection when clicking the back button', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      renderScanner('/scan/event1');
+
+      await waitFor(() => {
+        expect(screen.getByText('Select Activity Type')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /Back to Event Selection/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Select Event')).toBeInTheDocument();
+      });
+    });
+
     it('should allow direct scanner access to a backup activity', async () => {
       mockEvents[0].activities = [
         {

--- a/frontend/src/components/Scanner/index.jsx
+++ b/frontend/src/components/Scanner/index.jsx
@@ -58,7 +58,9 @@ export default function Scanner() {
 
         if (urlEventId) {
           const match = eventsList.find(e => e.id === urlEventId);
-          if (match) setLocalEvent(match);
+          setLocalEvent(match || null);
+        } else {
+          setLocalEvent(null);
         }
       } catch (err) {
         console.error("Error loading scanner data:", err);


### PR DESCRIPTION
## Summary
- Clear stale scanner event state when navigating back to /scan
- Add regression coverage for the Back to Event Selection button

## Tests
- npm test -- Scanner.test.jsx
- git diff --check

Closes #85