### PR TITLE
Keep scanner feedback above camera overlay

### DIFF
--- a/frontend/src/components/Scanner/Scanner.test.jsx
+++ b/frontend/src/components/Scanner/Scanner.test.jsx
@@ -337,8 +337,8 @@ describe('Scanner', () => {
       });
     });
 
-    it('should show scan feedback in a fixed top toast', async () => {
-      renderScanner('/scan/event1/general/checkin');
+    it('should show scan feedback in a fixed top body-level toast', async () => {
+      const { container } = renderScanner('/scan/event1/general/checkin');
 
       await waitFor(() => {
         expect(mockUseQRScannerOptions).not.toBeNull();
@@ -350,7 +350,11 @@ describe('Scanner', () => {
 
       const toast = screen.getByRole('status', { name: 'Scan result' });
       expect(toast).toHaveTextContent('✓ Test Student Checked In');
-      expect(toast.parentElement).toHaveClass('fixed', 'top-3', 'z-50');
+      expect(toast.parentElement).toHaveClass('fixed', 'z-[2147483647]');
+      expect(toast.parentElement).toHaveStyle({
+        top: 'calc(env(safe-area-inset-top, 0px) + 0.75rem)',
+      });
+      expect(container).not.toContain(toast);
     });
   });
 

--- a/frontend/src/components/Scanner/index.jsx
+++ b/frontend/src/components/Scanner/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { db, functions } from '../../utils/firebase';
 import { doc, getDoc, collection, getDocs } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
@@ -9,6 +10,31 @@ import Spinner from '../common/Spinner';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { parseQRData } from '../../utils/qrCodeGenerator';
 import { useAuth } from '../../contexts/AuthContext';
+
+function ScanResultToast({ message }) {
+  if (!message) return null;
+
+  return createPortal(
+    <div
+      className="pointer-events-none fixed inset-x-3 z-[2147483647] mx-auto max-w-md"
+      style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.75rem)' }}
+    >
+      <div
+        role={message.type === 'error' ? 'alert' : 'status'}
+        aria-live={message.type === 'error' ? 'assertive' : 'polite'}
+        aria-label="Scan result"
+        className={`rounded-xl border-2 px-4 py-3 shadow-2xl ${
+          message.type === 'success'
+            ? 'border-green-300 bg-green-50 text-green-900'
+            : 'border-red-300 bg-red-50 text-red-900'
+        }`}
+      >
+        <p className="text-center text-base font-black leading-snug sm:text-lg">{message.text}</p>
+      </div>
+    </div>,
+    document.body
+  );
+}
 
 export default function Scanner() {
   const { eventId: urlEventId, activityId: urlActivityId, action: urlAction } = useParams();
@@ -366,22 +392,7 @@ export default function Scanner() {
   return (
     <div className="min-h-screen bg-gray-50">
       <ScannerHeader />
-      {message && (
-        <div className="pointer-events-none fixed inset-x-3 top-3 z-50 mx-auto max-w-md sm:top-4">
-          <div
-            role={message.type === 'error' ? 'alert' : 'status'}
-            aria-live={message.type === 'error' ? 'assertive' : 'polite'}
-            aria-label="Scan result"
-            className={`rounded-xl border-2 px-4 py-3 shadow-2xl ${
-              message.type === 'success'
-                ? 'border-green-300 bg-green-50 text-green-900'
-                : 'border-red-300 bg-red-50 text-red-900'
-            }`}
-          >
-            <p className="text-center text-base font-black leading-snug sm:text-lg">{message.text}</p>
-          </div>
-        </div>
-      )}
+      <ScanResultToast message={message} />
       <div className="max-w-2xl mx-auto p-4">
         <div className="bg-white rounded-lg shadow-md p-6 mb-4 border-t-4 border-primary-600">
           <div className="flex justify-between items-center">


### PR DESCRIPTION
## Summary
- Render scanner feedback toast through a body-level React portal so it is not inside the scanner layout tree
- Raise the toast z-index above camera/scanner overlays and respect iPhone safe-area top spacing
- Update the regression test to verify the toast is body-level and uses the stronger overlay layer

## Context
Follow-up to #88 / #71 after production testing showed the toast could still appear underneath the scanner viewport.

## Tests
- npm test -- Scanner.test.jsx
- npm run build