### PR TITLE
Fix service log detail activity rendering

### DIFF
--- a/frontend/src/utils/pdfTemplateUtils.js
+++ b/frontend/src/utils/pdfTemplateUtils.js
@@ -211,7 +211,10 @@ export function resolveDetailColumnValue(columnKey, entry, event) {
       return '0';
     }
     case 'detailActivity':
-      return entry.activityName || '';
+      return entry.activityName ||
+        entry.activity?.name ||
+        event?.activities?.find(activity => activity.id === entry.activityId)?.name ||
+        '';
     case 'detailContact':
       return event?.contactName || '';
     default:

--- a/frontend/src/utils/pdfTemplateUtils.test.js
+++ b/frontend/src/utils/pdfTemplateUtils.test.js
@@ -302,6 +302,30 @@ describe('pdfTemplateUtils', () => {
       expect(resolveDetailColumnValue('detailActivity', mockEntry)).toBe('VBS Morning Session');
     });
 
+    it('should resolve detailActivity from an embedded activity object', () => {
+      expect(resolveDetailColumnValue('detailActivity', {
+        ...mockEntry,
+        activityName: '',
+        activity: { name: 'Embedded Activity' },
+      })).toBe('Embedded Activity');
+    });
+
+    it('should resolve detailActivity from event activities by activityId', () => {
+      const entry = {
+        ...mockEntry,
+        activityName: '',
+        activityId: 'activity2',
+      };
+      const event = {
+        activities: [
+          { id: 'activity1', name: 'Morning Session' },
+          { id: 'activity2', name: 'Afternoon Session' },
+        ],
+      };
+
+      expect(resolveDetailColumnValue('detailActivity', entry, event)).toBe('Afternoon Session');
+    });
+
     it('should resolve detailContact from event data', () => {
       expect(resolveDetailColumnValue('detailContact', mockEntry, mockEvent)).toBe('Jane Smith');
     });


### PR DESCRIPTION
## Summary
- Resolve detail table Activity values from embedded activity data or event activities by activityId
- Preserve existing activityName behavior
- Add regression coverage for both fallback shapes

Closes #98

## Tests
- npm test -- --run src/utils/pdfTemplateUtils.test.js