### PR TITLE
Add custom fields to PDF table rows

### DIFF
--- a/frontend/src/pages/PdfTemplatesPage.jsx
+++ b/frontend/src/pages/PdfTemplatesPage.jsx
@@ -57,6 +57,19 @@ function buildTableColumn(option, index, isDetail) {
   };
 }
 
+function buildCustomTableColumn(isDetail) {
+  return {
+    key: `custom_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+    type: 'customText',
+    label: 'Custom Text',
+    customValue: '',
+    xPercent: isDetail ? 3 : 5,
+    fontSize: 10,
+    maxWidth: isDetail ? 15 : 20,
+    enabled: true,
+  };
+}
+
 export default function PdfTemplatesPage() {
   const [templates, setTemplates] = useState([]);
   const [defaultTemplateId, setDefaultTemplateId] = useState(null);
@@ -856,6 +869,12 @@ function FieldMapperModal({ isOpen, template, onClose }) {
     ));
   };
 
+  const addTableCustomColumn = (tableType) => {
+    const isDetail = tableType === 'detailTable';
+    const updateColumns = isDetail ? setDtColumns : setAtColumns;
+    updateColumns(prev => [...prev, buildCustomTableColumn(isDetail)]);
+  };
+
   const removeField = (fieldId) => {
     setFields(prev => prev.filter(f => f.id !== fieldId));
     if (selectedFieldId === fieldId) setSelectedFieldId(null);
@@ -991,17 +1010,54 @@ function FieldMapperModal({ isOpen, template, onClose }) {
               <div className="space-y-1">
                 {atColumns.map((col, idx) => (
                   <div key={col.key} className="flex items-center gap-2 text-sm">
-                    <input
-                      type="checkbox"
-                      checked={col.enabled}
-                      onChange={(e) => {
-                        const updated = [...atColumns];
-                        updated[idx] = { ...updated[idx], enabled: e.target.checked };
-                        setAtColumns(updated);
-                      }}
-                      className="rounded"
-                    />
-                    <span className="w-40 text-gray-700">{col.label}</span>
+                    {col.type === 'customText' ? (
+                      <button
+                        type="button"
+                        onClick={() => setAtColumns(prev => prev.filter(item => item.key !== col.key))}
+                        className="text-red-500 hover:text-red-700 text-xs font-medium w-5"
+                      >
+                        x
+                      </button>
+                    ) : (
+                      <input
+                        type="checkbox"
+                        checked={col.enabled}
+                        onChange={(e) => {
+                          const updated = [...atColumns];
+                          updated[idx] = { ...updated[idx], enabled: e.target.checked };
+                          setAtColumns(updated);
+                        }}
+                        className="rounded"
+                      />
+                    )}
+                    {col.type === 'customText' ? (
+                      <>
+                        <input
+                          type="text"
+                          value={col.label}
+                          onChange={(e) => {
+                            const updated = [...atColumns];
+                            updated[idx] = { ...updated[idx], label: e.target.value };
+                            setAtColumns(updated);
+                          }}
+                          placeholder="Label"
+                          className="input-field text-sm w-36"
+                        />
+                        <input
+                          type="text"
+                          value={col.customValue || ''}
+                          onChange={(e) => {
+                            const updated = [...atColumns];
+                            updated[idx] = { ...updated[idx], customValue: e.target.value };
+                            setAtColumns(updated);
+                          }}
+                          placeholder="Value for every row"
+                          className="input-field text-sm w-40"
+                        />
+                      </>
+                    ) : (
+                      <span className="w-40 text-gray-700">{col.label}</span>
+                    )}
                     <label className="text-xs text-gray-500">X%:</label>
                     <input
                       type="number"
@@ -1043,6 +1099,9 @@ function FieldMapperModal({ isOpen, template, onClose }) {
                     />
                   </div>
                 ))}
+                <Button size="sm" variant="secondary" onClick={() => addTableCustomColumn('activityTable')}>
+                  Add Custom Column
+                </Button>
               </div>
               <p className="text-xs text-primary-600">Click on the PDF where the first row should start. Drag columns to position them independently.</p>
             </div>
@@ -1081,17 +1140,54 @@ function FieldMapperModal({ isOpen, template, onClose }) {
               <div className="space-y-1">
                 {dtColumns.map((col, idx) => (
                   <div key={col.key} className="flex items-center gap-2 text-sm">
-                    <input
-                      type="checkbox"
-                      checked={col.enabled}
-                      onChange={(e) => {
-                        const updated = [...dtColumns];
-                        updated[idx] = { ...updated[idx], enabled: e.target.checked };
-                        setDtColumns(updated);
-                      }}
-                      className="rounded"
-                    />
-                    <span className="w-40 text-gray-700">{col.label}</span>
+                    {col.type === 'customText' ? (
+                      <button
+                        type="button"
+                        onClick={() => setDtColumns(prev => prev.filter(item => item.key !== col.key))}
+                        className="text-red-500 hover:text-red-700 text-xs font-medium w-5"
+                      >
+                        x
+                      </button>
+                    ) : (
+                      <input
+                        type="checkbox"
+                        checked={col.enabled}
+                        onChange={(e) => {
+                          const updated = [...dtColumns];
+                          updated[idx] = { ...updated[idx], enabled: e.target.checked };
+                          setDtColumns(updated);
+                        }}
+                        className="rounded"
+                      />
+                    )}
+                    {col.type === 'customText' ? (
+                      <>
+                        <input
+                          type="text"
+                          value={col.label}
+                          onChange={(e) => {
+                            const updated = [...dtColumns];
+                            updated[idx] = { ...updated[idx], label: e.target.value };
+                            setDtColumns(updated);
+                          }}
+                          placeholder="Label"
+                          className="input-field text-sm w-36"
+                        />
+                        <input
+                          type="text"
+                          value={col.customValue || ''}
+                          onChange={(e) => {
+                            const updated = [...dtColumns];
+                            updated[idx] = { ...updated[idx], customValue: e.target.value };
+                            setDtColumns(updated);
+                          }}
+                          placeholder="Value for every row"
+                          className="input-field text-sm w-40"
+                        />
+                      </>
+                    ) : (
+                      <span className="w-40 text-gray-700">{col.label}</span>
+                    )}
                     <label className="text-xs text-gray-500">X%:</label>
                     <input
                       type="number"
@@ -1133,6 +1229,9 @@ function FieldMapperModal({ isOpen, template, onClose }) {
                     />
                   </div>
                 ))}
+                <Button size="sm" variant="secondary" onClick={() => addTableCustomColumn('detailTable')}>
+                  Add Custom Column
+                </Button>
               </div>
               <p className="text-xs text-primary-600">Click on the PDF where the first row should start. Drag columns to position them independently.</p>
             </div>
@@ -1414,7 +1513,9 @@ function FieldMarker({ field, isSelected, showPreview, previewScale, onMouseDown
 
       {/* Column position markers - each independently draggable */}
       {columns.map(col => {
-        const colPreview = columnOptions.find(o => o.key === col.key)?.preview || col.label;
+        const colPreview = col.type === 'customText'
+          ? (col.customValue || col.label)
+          : (columnOptions.find(o => o.key === col.key)?.preview || col.label);
         const displayFontSize = (col.fontSize || 10) * previewScale;
         const isColDragging = draggingColKey === col.key;
 
@@ -1494,6 +1595,13 @@ function SelectedFieldEditor({ field, onUpdate, onRemove }) {
     const columnOptions = isDetail ? DETAIL_COLUMN_OPTIONS : ACTIVITY_COLUMN_OPTIONS;
     const columns = field.columns || [];
     const columnsByKey = new Map(columns.map(col => [col.key, col]));
+    const customColumns = columns.filter(col => col.type === 'customText');
+
+    const updateColumn = (columnIndex, updates) => {
+      const updated = [...columns];
+      updated[columnIndex] = { ...updated[columnIndex], ...updates };
+      onUpdate({ columns: updated });
+    };
 
     const toggleColumn = (option, optionIndex, enabled) => {
       if (!enabled) {
@@ -1507,6 +1615,14 @@ function SelectedFieldEditor({ field, onUpdate, onRemove }) {
       const optionOrder = new Map(columnOptions.map((opt, index) => [opt.key, index]));
       nextColumns.sort((a, b) => (optionOrder.get(a.key) ?? 999) - (optionOrder.get(b.key) ?? 999));
       onUpdate({ columns: nextColumns });
+    };
+
+    const addCustomColumn = () => {
+      onUpdate({ columns: [...columns, buildCustomTableColumn(isDetail)] });
+    };
+
+    const removeCustomColumn = (columnKey) => {
+      onUpdate({ columns: columns.filter(col => col.key !== columnKey) });
     };
 
     return (
@@ -1576,11 +1692,7 @@ function SelectedFieldEditor({ field, onUpdate, onRemove }) {
                     <input
                       type="number"
                       value={col.xPercent}
-                      onChange={(e) => {
-                        const updated = [...columns];
-                        updated[columnIndex] = { ...updated[columnIndex], xPercent: Number(e.target.value) };
-                        onUpdate({ columns: updated });
-                      }}
+                      onChange={(e) => updateColumn(columnIndex, { xPercent: Number(e.target.value) })}
                       min={0}
                       max={100}
                       step={0.5}
@@ -1590,11 +1702,7 @@ function SelectedFieldEditor({ field, onUpdate, onRemove }) {
                     <input
                       type="number"
                       value={col.fontSize}
-                      onChange={(e) => {
-                        const updated = [...columns];
-                        updated[columnIndex] = { ...updated[columnIndex], fontSize: Number(e.target.value) };
-                        onUpdate({ columns: updated });
-                      }}
+                      onChange={(e) => updateColumn(columnIndex, { fontSize: Number(e.target.value) })}
                       min={6}
                       max={24}
                       className="input-field text-sm w-14"
@@ -1603,11 +1711,7 @@ function SelectedFieldEditor({ field, onUpdate, onRemove }) {
                     <input
                       type="number"
                       value={col.maxWidth || 0}
-                      onChange={(e) => {
-                        const updated = [...columns];
-                        updated[columnIndex] = { ...updated[columnIndex], maxWidth: Number(e.target.value) || 0 };
-                        onUpdate({ columns: updated });
-                      }}
+                      onChange={(e) => updateColumn(columnIndex, { maxWidth: Number(e.target.value) || 0 })}
                       min={0}
                       max={100}
                       className="input-field text-sm w-14"
@@ -1617,6 +1721,63 @@ function SelectedFieldEditor({ field, onUpdate, onRemove }) {
               </div>
             );
           })}
+          {customColumns.map((col) => {
+            const columnIndex = columns.findIndex(item => item.key === col.key);
+            return (
+              <div key={col.key} className={`flex items-center gap-2 text-sm bg-white p-2 rounded border ${colBorderColor}`}>
+                <button
+                  type="button"
+                  onClick={() => removeCustomColumn(col.key)}
+                  className="text-red-500 hover:text-red-700 text-xs font-medium w-5"
+                >
+                  x
+                </button>
+                <input
+                  type="text"
+                  value={col.label}
+                  onChange={(e) => updateColumn(columnIndex, { label: e.target.value })}
+                  placeholder="Label"
+                  className="input-field text-sm w-36"
+                />
+                <input
+                  type="text"
+                  value={col.customValue || ''}
+                  onChange={(e) => updateColumn(columnIndex, { customValue: e.target.value })}
+                  placeholder="Value for every row"
+                  className="input-field text-sm w-40"
+                />
+                <label className={`text-xs ${colLabelColor}`}>X%:</label>
+                <input
+                  type="number"
+                  value={col.xPercent}
+                  onChange={(e) => updateColumn(columnIndex, { xPercent: Number(e.target.value) })}
+                  min={0}
+                  max={100}
+                  step={0.5}
+                  className="input-field text-sm w-16"
+                />
+                <label className={`text-xs ${colLabelColor}`}>Font:</label>
+                <input
+                  type="number"
+                  value={col.fontSize}
+                  onChange={(e) => updateColumn(columnIndex, { fontSize: Number(e.target.value) })}
+                  min={6}
+                  max={24}
+                  className="input-field text-sm w-14"
+                />
+                <label className={`text-xs ${colLabelColor}`}>MaxW%:</label>
+                <input
+                  type="number"
+                  value={col.maxWidth || 0}
+                  onChange={(e) => updateColumn(columnIndex, { maxWidth: Number(e.target.value) || 0 })}
+                  min={0}
+                  max={100}
+                  className="input-field text-sm w-14"
+                />
+              </div>
+            );
+          })}
+          <Button size="sm" variant="secondary" onClick={addCustomColumn}>Add Custom Column</Button>
         </div>
       </div>
     );

--- a/frontend/src/pages/PdfTemplatesPage.test.jsx
+++ b/frontend/src/pages/PdfTemplatesPage.test.jsx
@@ -351,6 +351,54 @@ describe('PdfTemplatesPage', () => {
       });
     });
 
+    it('should allow adding a custom column while placing an activity table', async () => {
+      const user = userEvent.setup();
+      await openFieldMapper(user);
+
+      await user.click(screen.getByRole('button', { name: /Place Activity Table/i }));
+      await user.click(screen.getByRole('button', { name: /Add Custom Column/i }));
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Value for every row')).toBeInTheDocument();
+      });
+    });
+
+    it('should allow editing custom columns on a placed detail table', async () => {
+      const user = userEvent.setup();
+      await openFieldMapper(user, {
+        fields: [
+          {
+            id: 'dt-custom',
+            type: 'detailTable',
+            label: 'Detail Table',
+            xPercent: 5,
+            yPercent: 30,
+            rowHeight: 3,
+            maxRows: 10,
+            columns: [
+              { key: 'detailDate', label: 'Date', xPercent: 5, fontSize: 10 },
+              {
+                key: 'custom_supervisor',
+                type: 'customText',
+                label: 'Supervisor',
+                customValue: 'Program Director',
+                xPercent: 40,
+                fontSize: 10,
+              },
+            ],
+            page: 0,
+          },
+        ],
+      });
+
+      await user.click(screen.getAllByText('Detail Table')[0]);
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('Supervisor')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('Program Director')).toBeInTheDocument();
+      });
+    });
+
     it('should show custom static field configuration when Place Custom Field is clicked', async () => {
       const user = userEvent.setup();
       await openFieldMapper(user);

--- a/frontend/src/utils/pdfTemplateUtils.js
+++ b/frontend/src/utils/pdfTemplateUtils.js
@@ -156,6 +156,10 @@ export function resolveFieldValue(fieldKey, { student, totalHours, eventName, ev
  * Resolves an activity column key to its value for a single activity row.
  */
 export function resolveActivityColumnValue(columnKey, activity, event) {
+  if (typeof columnKey === 'object' && columnKey?.type === 'customText') {
+    return columnKey.customValue || '';
+  }
+
   switch (columnKey) {
     case 'activityOrg':
       return `${event?.organizationName || ''} ${activity.name || ''}`.trim();
@@ -174,6 +178,10 @@ export function resolveActivityColumnValue(columnKey, activity, event) {
  * Resolves a detail column key to its value for a single time entry row.
  */
 export function resolveDetailColumnValue(columnKey, entry, event) {
+  if (typeof columnKey === 'object' && columnKey?.type === 'customText') {
+    return columnKey.customValue || '';
+  }
+
   switch (columnKey) {
     case 'detailDate': {
       // Support Firestore Timestamps (with toDate()) and regular Date/string values
@@ -262,7 +270,7 @@ export async function generateFilledPdf(templatePdfBytes, fields, data) {
           const colFontSize = col.fontSize || 10;
           // Shift baseline down by ascent so top of text aligns with yPercent
           const y = height - (rowYPct / 100) * height - (colFontSize * ASCENT_RATIO);
-          const value = String(resolveActivityColumnValue(col.key, activity, data.event));
+          const value = String(resolveActivityColumnValue(col.type === 'customText' ? col : col.key, activity, data.event));
 
           page.drawText(value, {
             x,
@@ -288,7 +296,7 @@ export async function generateFilledPdf(templatePdfBytes, fields, data) {
           const x = (col.xPercent / 100) * width;
           const colFontSize = col.fontSize || 10;
           const y = height - (rowYPct / 100) * height - (colFontSize * ASCENT_RATIO);
-          const value = String(resolveDetailColumnValue(col.key, entry, data.event));
+          const value = String(resolveDetailColumnValue(col.type === 'customText' ? col : col.key, entry, data.event));
 
           page.drawText(value, {
             x,

--- a/frontend/src/utils/pdfTemplateUtils.test.js
+++ b/frontend/src/utils/pdfTemplateUtils.test.js
@@ -75,6 +75,24 @@ describe('pdfTemplateUtils', () => {
     });
   });
 
+  describe('custom table column values', () => {
+    it('should resolve custom activity table column values', () => {
+      expect(resolveActivityColumnValue({
+        type: 'customText',
+        label: 'Type',
+        customValue: 'Community Service',
+      })).toBe('Community Service');
+    });
+
+    it('should resolve custom detail table column values', () => {
+      expect(resolveDetailColumnValue({
+        type: 'customText',
+        label: 'Supervisor',
+        customValue: 'Program Director',
+      })).toBe('Program Director');
+    });
+  });
+
   describe('DETAIL_COLUMN_OPTIONS', () => {
     it('should export an array of detail column options', () => {
       expect(Array.isArray(DETAIL_COLUMN_OPTIONS)).toBe(true);
@@ -648,6 +666,78 @@ describe('pdfTemplateUtils', () => {
         totalHours: 0,
         eventName: '',
         timeEntries: [],
+        event: {},
+      };
+
+      const result = await generateFilledPdf(templatePdfBytes, fields, data);
+      expect(result).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should generate activity tables with custom text columns on every row', async () => {
+      const fields = [
+        {
+          type: 'activityTable',
+          yPercent: 20,
+          rowHeight: 3,
+          maxRows: 2,
+          page: 0,
+          columns: [
+            { key: 'activityOrg', xPercent: 5, fontSize: 10 },
+            {
+              key: 'custom_service_type',
+              type: 'customText',
+              label: 'Type',
+              customValue: 'Community Service',
+              xPercent: 40,
+              fontSize: 10,
+            },
+          ],
+        },
+      ];
+      const data = {
+        student: { firstName: 'Jane', lastName: 'Smith' },
+        totalHours: 0,
+        eventName: '',
+        activityLog: [
+          { name: 'Morning', totalHours: '4.00' },
+          { name: 'Afternoon', totalHours: '3.00' },
+        ],
+        event: { organizationName: 'Church' },
+      };
+
+      const result = await generateFilledPdf(templatePdfBytes, fields, data);
+      expect(result).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should generate detail tables with custom text columns on every row', async () => {
+      const fields = [
+        {
+          type: 'detailTable',
+          yPercent: 20,
+          rowHeight: 3,
+          maxRows: 2,
+          page: 0,
+          columns: [
+            { key: 'detailDate', xPercent: 5, fontSize: 10 },
+            {
+              key: 'custom_supervisor',
+              type: 'customText',
+              label: 'Supervisor',
+              customValue: 'Program Director',
+              xPercent: 40,
+              fontSize: 10,
+            },
+          ],
+        },
+      ];
+      const data = {
+        student: { firstName: 'Jane', lastName: 'Smith' },
+        totalHours: 0,
+        eventName: '',
+        timeEntries: [
+          { date: '2026-06-09', hoursWorked: 4 },
+          { date: '2026-06-10', hoursWorked: 3 },
+        ],
         event: {},
       };
 


### PR DESCRIPTION
## Summary
- add custom text columns to activity and detail PDF tables
- let mapped tables edit/remove those custom columns after placement
- render custom table column values on every generated row

## Testing
- npm test -- --run src/utils/pdfTemplateUtils.test.js src/pages/PdfTemplatesPage.test.jsx
- npm run build

Fixes #99