### PR TITLE
Add event student removal workflow

### DIFF
--- a/frontend/src/pages/EventStudentsPage.jsx
+++ b/frontend/src/pages/EventStudentsPage.jsx
@@ -9,9 +9,11 @@ import {
     addDoc,
     deleteDoc,
     doc,
+    getDocs,
     query,
     where,
     serverTimestamp,
+    writeBatch,
 } from 'firebase/firestore';
 import { ref, getDownloadURL } from 'firebase/storage';
 import { generateFilledPdf, mergePdfs, openPdfForPrinting } from '../utils/pdfTemplateUtils';
@@ -210,6 +212,9 @@ export default function EventStudentsPage() {
     const selectedPrintCount = eventStudents.filter(s => selectedStudents.has(s.id)).length;
     const printStudentCount = selectedStudents.size > 0 ? selectedPrintCount : filteredStudents.length;
 
+    const getEventEntriesForStudent = (studentId) =>
+        eventEntries.filter(entry => entry.studentId === studentId);
+
     // Students not yet associated with this event (for import modal)
     const importableStudents = useMemo(() => {
         return allStudents
@@ -222,14 +227,58 @@ export default function EventStudentsPage() {
     }, [allStudents, eventStudentIds, checkedInStudentIds, importSearch]);
 
     const handleRemoveStudent = async (studentId) => {
+        const student = allStudents.find(s => s.id === studentId);
+        const studentName = student ? `${student.firstName} ${student.lastName}`.trim() : 'this student';
+        const studentEventEntries = getEventEntriesForStudent(studentId);
         const eventStudentDocId = eventStudentDocIds[studentId];
-        if (!eventStudentDocId) return;
+
+        if (studentEventEntries.length > 0) {
+            const confirmed = window.confirm(
+                `${studentName} has ${studentEventEntries.length} activity ` +
+                `record${studentEventEntries.length === 1 ? '' : 's'} for this event. ` +
+                'Remove them from the event and delete those activity records?'
+            );
+            if (!confirmed) return;
+        } else if (!eventStudentDocId) {
+            return;
+        }
 
         setRemovingStudentId(studentId);
         try {
-            await deleteDoc(doc(db, 'eventStudents', eventStudentDocId));
+            if (studentEventEntries.length === 0 && eventStudentDocId) {
+                await deleteDoc(doc(db, 'eventStudents', eventStudentDocId));
+                setSelectedStudents(prev => {
+                    const next = new Set(prev);
+                    next.delete(studentId);
+                    return next;
+                });
+                return;
+            }
+
+            const entriesQuery = query(
+                collection(db, 'timeEntries'),
+                where('eventId', '==', eventId),
+                where('studentId', '==', studentId)
+            );
+            const entriesSnapshot = await getDocs(entriesQuery);
+            const batch = writeBatch(db);
+
+            if (eventStudentDocId) {
+                batch.delete(doc(db, 'eventStudents', eventStudentDocId));
+            }
+            entriesSnapshot.docs.forEach(entryDoc => {
+                batch.delete(entryDoc.ref);
+            });
+
+            await batch.commit();
+            setSelectedStudents(prev => {
+                const next = new Set(prev);
+                next.delete(studentId);
+                return next;
+            });
         } catch (err) {
             console.error('Error removing student:', err);
+            alert('Failed to remove student from event: ' + err.message);
         } finally {
             setRemovingStudentId(null);
         }
@@ -598,20 +647,19 @@ export default function EventStudentsPage() {
                                             >
                                                 View Details
                                             </Link>
-                                            {eventStudentDocIds[s.id] && !checkedInStudentIds.has(s.id) && (
+                                            {(eventStudentDocIds[s.id] || getEventEntriesForStudent(s.id).length > 0) && (
                                                 <button
                                                     type="button"
                                                     onClick={() => handleRemoveStudent(s.id)}
                                                     disabled={removingStudentId === s.id}
                                                     className="text-xs font-bold text-red-500 hover:text-red-700 disabled:opacity-50"
+                                                    title={getEventEntriesForStudent(s.id).length > 0
+                                                        ? 'Removes this student and deletes their event activity records'
+                                                        : 'Remove this student from the event'
+                                                    }
                                                 >
                                                     {removingStudentId === s.id ? 'Removing...' : 'Remove'}
                                                 </button>
-                                            )}
-                                            {checkedInStudentIds.has(s.id) && (
-                                                <span className="text-xs text-gray-300" title="Cannot remove a student with time entries">
-                                                    Remove
-                                                </span>
                                             )}
                                         </div>
                                     </td>

--- a/frontend/src/pages/EventStudentsPage.jsx
+++ b/frontend/src/pages/EventStudentsPage.jsx
@@ -232,16 +232,17 @@ export default function EventStudentsPage() {
         const studentEventEntries = getEventEntriesForStudent(studentId);
         const eventStudentDocId = eventStudentDocIds[studentId];
 
-        if (studentEventEntries.length > 0) {
-            const confirmed = window.confirm(
-                `${studentName} has ${studentEventEntries.length} activity ` +
-                `record${studentEventEntries.length === 1 ? '' : 's'} for this event. ` +
-                'Remove them from the event and delete those activity records?'
-            );
-            if (!confirmed) return;
-        } else if (!eventStudentDocId) {
+        if (!eventStudentDocId && studentEventEntries.length === 0) {
             return;
         }
+
+        const confirmMessage = studentEventEntries.length > 0
+            ? `${studentName} has ${studentEventEntries.length} activity ` +
+                `record${studentEventEntries.length === 1 ? '' : 's'} for this event. ` +
+                'Remove them from the event and delete those activity records?'
+            : `Remove ${studentName} from this event? Their student record will remain in the system.`;
+
+        if (!window.confirm(confirmMessage)) return;
 
         setRemovingStudentId(studentId);
         try {

--- a/frontend/src/pages/EventStudentsPage.test.jsx
+++ b/frontend/src/pages/EventStudentsPage.test.jsx
@@ -49,12 +49,14 @@ const defaultPdfTemplates = [
 let onSnapshotCalls = [];
 let addDocMock;
 let mockPdfTemplates = [...defaultPdfTemplates];
+let mockBatchDelete;
+let mockBatchCommit;
 
 vi.mock('firebase/firestore', () => ({
     collection: vi.fn((db, path) => ({ _collPath: path })),
     doc: vi.fn((db, col, id) => ({ _isDoc: true, _docPath: `${col}/${id}` })),
-    query: vi.fn((ref) => ref),
-    where: vi.fn(() => ({})),
+    query: vi.fn((ref, ...constraints) => ({ ...ref, _constraints: constraints })),
+    where: vi.fn((field, operator, value) => ({ field, operator, value })),
     deleteDoc: vi.fn().mockResolvedValue(undefined),
     onSnapshot: vi.fn((queryOrRef, callback) => {
         if (queryOrRef?._isDoc) {
@@ -99,8 +101,26 @@ vi.mock('firebase/firestore', () => ({
         return unsub;
     }),
     addDoc: vi.fn().mockResolvedValue({ id: 'newDoc' }),
-    getDocs: vi.fn().mockResolvedValue({ docs: [] }),
+    getDocs: vi.fn((queryRef) => {
+        const studentConstraint = queryRef?._constraints?.find(c => c.field === 'studentId');
+        if (queryRef?._collPath === 'timeEntries' && studentConstraint?.value === 'student2') {
+            return Promise.resolve({
+                docs: [
+                    { id: 'te1', ref: { _docPath: 'timeEntries/te1' } },
+                ],
+            });
+        }
+        return Promise.resolve({ docs: [] });
+    }),
     serverTimestamp: vi.fn(() => ({})),
+    writeBatch: vi.fn(() => {
+        mockBatchDelete = vi.fn();
+        mockBatchCommit = vi.fn().mockResolvedValue(undefined);
+        return {
+            delete: mockBatchDelete,
+            commit: mockBatchCommit,
+        };
+    }),
 }));
 
 vi.mock('../contexts/AuthContext', () => ({
@@ -125,7 +145,10 @@ describe('EventStudentsPage', () => {
         vi.clearAllMocks();
         onSnapshotCalls = [];
         mockPdfTemplates = [...defaultPdfTemplates];
+        mockBatchDelete = vi.fn();
+        mockBatchCommit = vi.fn().mockResolvedValue(undefined);
         window.alert = vi.fn();
+        window.confirm = vi.fn(() => true);
         global.fetch = vi.fn(() => Promise.resolve({
             arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
         }));
@@ -364,31 +387,65 @@ describe('EventStudentsPage', () => {
             expect(screen.getByText('Alice Adams')).toBeInTheDocument();
         });
 
-        const removeButton = screen.getByRole('button', { name: /^Remove$/ });
+        const aliceRow = screen.getByText('Alice Adams').closest('tr');
+        const removeButton = within(aliceRow).getByRole('button', { name: /^Remove$/ });
         expect(removeButton).toBeInTheDocument();
         expect(removeButton).not.toBeDisabled();
     });
 
-    it('does not show an active Remove button for students with time entries', async () => {
+    it('shows an active Remove button for students with time entries', async () => {
         renderPage();
         await waitFor(() => {
             expect(screen.getByText('Bob Brown')).toBeInTheDocument();
         });
 
-        expect(screen.getAllByRole('button', { name: /^Remove$/ })).toHaveLength(1);
-        expect(screen.getByTitle('Cannot remove a student with time entries')).toBeInTheDocument();
+        expect(screen.getAllByRole('button', { name: /^Remove$/ })).toHaveLength(2);
+        expect(screen.getByTitle('Removes this student and deletes their event activity records')).toBeInTheDocument();
     });
 
     it('deletes the eventStudents association when Remove is clicked', async () => {
         const { deleteDoc, doc } = await import('firebase/firestore');
 
         renderPage();
-        await waitFor(() => screen.getByRole('button', { name: /^Remove$/ }));
-        fireEvent.click(screen.getByRole('button', { name: /^Remove$/ }));
+        await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+
+        const aliceRow = screen.getByText('Alice Adams').closest('tr');
+        fireEvent.click(within(aliceRow).getByRole('button', { name: /^Remove$/ }));
 
         await waitFor(() => {
             expect(doc).toHaveBeenCalledWith({}, 'eventStudents', 'es1');
             expect(deleteDoc).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it('asks before removing a student with activity records', async () => {
+        const { getDocs } = await import('firebase/firestore');
+        window.confirm = vi.fn(() => false);
+
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Bob Brown')).toBeInTheDocument());
+
+        const bobRow = screen.getByText('Bob Brown').closest('tr');
+        fireEvent.click(within(bobRow).getByRole('button', { name: /^Remove$/ }));
+
+        expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('Bob Brown has 1 activity record'));
+        expect(getDocs).not.toHaveBeenCalled();
+    });
+
+    it('deletes event-scoped time entries when confirmed', async () => {
+        const { getDocs, writeBatch } = await import('firebase/firestore');
+
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Bob Brown')).toBeInTheDocument());
+
+        const bobRow = screen.getByText('Bob Brown').closest('tr');
+        fireEvent.click(within(bobRow).getByRole('button', { name: /^Remove$/ }));
+
+        await waitFor(() => {
+            expect(getDocs).toHaveBeenCalledTimes(1);
+            expect(writeBatch).toHaveBeenCalledWith({});
+            expect(mockBatchDelete).toHaveBeenCalledWith({ _docPath: 'timeEntries/te1' });
+            expect(mockBatchCommit).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/frontend/src/pages/EventStudentsPage.test.jsx
+++ b/frontend/src/pages/EventStudentsPage.test.jsx
@@ -413,9 +413,28 @@ describe('EventStudentsPage', () => {
         fireEvent.click(within(aliceRow).getByRole('button', { name: /^Remove$/ }));
 
         await waitFor(() => {
+            expect(window.confirm).toHaveBeenCalledWith(
+                'Remove Alice Adams from this event? Their student record will remain in the system.'
+            );
             expect(doc).toHaveBeenCalledWith({}, 'eventStudents', 'es1');
             expect(deleteDoc).toHaveBeenCalledTimes(1);
         });
+    });
+
+    it('does not remove a roster-only student when confirmation is cancelled', async () => {
+        const { deleteDoc } = await import('firebase/firestore');
+        window.confirm = vi.fn(() => false);
+
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+
+        const aliceRow = screen.getByText('Alice Adams').closest('tr');
+        fireEvent.click(within(aliceRow).getByRole('button', { name: /^Remove$/ }));
+
+        expect(window.confirm).toHaveBeenCalledWith(
+            'Remove Alice Adams from this event? Their student record will remain in the system.'
+        );
+        expect(deleteDoc).not.toHaveBeenCalled();
     });
 
     it('asks before removing a student with activity records', async () => {


### PR DESCRIPTION
## Summary
- add active Remove support for event students with activity records
- confirm before deleting event-scoped time entries, then remove those records in a Firestore batch
- keep roster-only removal as a simple eventStudents association delete
- update EventStudentsPage tests for roster-only, cancel, and confirmed removal paths

Closes #96

## Verification
- npm test -- src/pages/EventStudentsPage.test.jsx
- npm test
- npm run build

Note: npm run lint is blocked by the frontend project missing an ESLint config.