### PR TITLE
Add event recent activity page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,7 @@ import UsersPage from './pages/UsersPage';
 import PdfTemplatesPage from './pages/PdfTemplatesPage';
 import EventStudentsPage from './pages/EventStudentsPage';
 import CheckHoursPage from './pages/CheckHoursPage';
+import ActivityPage from './pages/ActivityPage';
 
 // Loading Spinner Component
 function LoadingSpinner() {
@@ -182,6 +183,7 @@ function App() {
               }
             >
               <Route index element={<AdminDashboardPage />} />
+              <Route path="activity" element={<ActivityPage />} />
               <Route path="daily-review" element={<DailyReviewPage />} />
               <Route path="forms" element={<FormGenerationPage />} />
               <Route path="students" element={<EventStudentsPage />} />

--- a/frontend/src/components/ActivityFeed/ActivityFeedList.jsx
+++ b/frontend/src/components/ActivityFeed/ActivityFeedList.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { formatActivityDateTime, formatActivityTime } from '../../utils/activityFeed';
+
+export default function ActivityFeedList({
+  items,
+  emptyMessage = 'No recent activity',
+  timestampFormat = 'time',
+}) {
+  if (items.length === 0) {
+    return <p className="text-sm text-gray-500">{emptyMessage}</p>;
+  }
+
+  const formatTimestamp = timestampFormat === 'datetime'
+    ? formatActivityDateTime
+    : formatActivityTime;
+
+  return (
+    <div className="divide-y divide-gray-100" role="list" aria-label="Activity feed">
+      {items.map(item => (
+        <div key={item.id} className="py-3" role="listitem">
+          <div className="flex justify-between gap-3">
+            <span className="font-bold text-gray-800">{item.studentName}</span>
+            <span className="whitespace-nowrap text-sm text-gray-500">
+              {formatTimestamp(item.actionTime)}
+            </span>
+          </div>
+          <div className="mt-1 flex justify-between gap-3 text-xs">
+            <span className="font-semibold text-gray-700">{item.actionLabel}</span>
+            <span className="text-right text-gray-500">{item.detail}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/AdminDashboard/AdminDashboard.test.jsx
+++ b/frontend/src/components/AdminDashboard/AdminDashboard.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import AdminDashboard from './index';
 
 const mockStudents = [
@@ -8,6 +9,12 @@ const mockStudents = [
 ];
 
 let mockTimeEntries = [];
+
+const renderDashboard = () => render(
+  <MemoryRouter>
+    <AdminDashboard />
+  </MemoryRouter>
+);
 
 vi.mock('../../utils/firebase', () => ({ db: {} }));
 
@@ -64,7 +71,7 @@ describe('AdminDashboard recent activity', () => {
       }
     ];
 
-    render(<AdminDashboard />);
+    renderDashboard();
 
     await waitFor(() => {
       expect(screen.getByText('Alice Adams')).toBeInTheDocument();
@@ -104,18 +111,24 @@ describe('AdminDashboard recent activity', () => {
       }
     ];
 
-    render(<AdminDashboard />);
+    renderDashboard();
 
     await waitFor(() => {
       expect(screen.getByText('Modified')).toBeInTheDocument();
     });
 
-    const activityPanel = screen.getByText('🔔 Recent Activity').closest('div');
+    const activityPanel = screen.getByText('🔔 Recent Activity').closest('.bg-white');
     const rows = within(activityPanel).getAllByText(/Alice Adams|Bob Brown/);
 
     expect(rows[0]).toHaveTextContent('Alice Adams');
     expect(rows[1]).toHaveTextContent('Bob Brown');
     expect(screen.getByText('Manual Entry')).toBeInTheDocument();
     expect(screen.getByText('Afternoon Session logged')).toBeInTheDocument();
+  });
+
+  it('links to the full activity page', async () => {
+    renderDashboard();
+
+    expect(await screen.findByRole('link', { name: 'View all' })).toHaveAttribute('href', '/admin/activity');
   });
 });

--- a/frontend/src/components/AdminDashboard/index.jsx
+++ b/frontend/src/components/AdminDashboard/index.jsx
@@ -1,104 +1,11 @@
 import React, { useState, useEffect, useMemo } from 'react'; //
 import { db } from '../../utils/firebase'; //
 import { collection, onSnapshot } from 'firebase/firestore'; //
+import { Link } from 'react-router-dom';
+import ActivityFeedList from '../ActivityFeed/ActivityFeedList';
 import { useEvent } from '../../contexts/EventContext'; // Add this
 import { useTimeEntries } from '../../hooks/useTimeEntries'; // Add this
-
-const convertToDate = (timeValue) => {
-  if (!timeValue) return null;
-  if (timeValue instanceof Date) return timeValue;
-  if (typeof timeValue.toDate === 'function') return timeValue.toDate();
-  return new Date(timeValue);
-};
-
-const formatActivityTime = (timeValue) => {
-  const date = convertToDate(timeValue);
-  return date && !Number.isNaN(date.getTime()) ? date.toLocaleTimeString() : '--';
-};
-
-const getMethodLabel = (method) => {
-  if (method === 'manual') return 'manual';
-  if (method === 'self_scan') return 'self-scan';
-  if (method === 'av_scan') return 'AV scan';
-  return 'scan';
-};
-
-const getChangeTypeLabel = (type) => {
-  switch (type) {
-    case 'void':
-      return 'Voided';
-    case 'restore':
-      return 'Restored';
-    case 'force_checkout':
-    case 'bulk_force_checkout':
-      return 'Forced Check-Out';
-    case 'edit':
-    default:
-      return 'Modified';
-  }
-};
-
-const buildRecentActivityItems = (timeEntries, studentNameMap, activityNameMap) => {
-  return timeEntries
-    .flatMap(entry => {
-      const studentName = studentNameMap[entry.studentId] || 'Student';
-      const activityName = activityNameMap[entry.activityId] || 'Activity';
-      const items = [];
-      const isManualEntry = entry.entry_source === 'manual' || (
-        entry.checkInMethod === 'manual' && entry.checkOutMethod === 'manual'
-      );
-
-      if (isManualEntry) {
-        const actionTime = convertToDate(entry.modifiedAt || entry.createdAt || entry.checkInTime);
-        items.push({
-          id: `${entry.id}-manual-entry`,
-          studentName,
-          actionLabel: 'Manual Entry',
-          detail: `${activityName} logged`,
-          actionTime,
-          sortTime: actionTime?.getTime() || 0
-        });
-      } else if (entry.checkInTime) {
-        const actionTime = convertToDate(entry.checkInTime);
-        items.push({
-          id: `${entry.id}-check-in`,
-          studentName,
-          actionLabel: 'Check-In',
-          detail: `${activityName} via ${getMethodLabel(entry.checkInMethod)}`,
-          actionTime,
-          sortTime: actionTime?.getTime() || 0
-        });
-      }
-
-      if (!isManualEntry && entry.checkOutTime) {
-        const actionTime = convertToDate(entry.checkOutTime);
-        items.push({
-          id: `${entry.id}-check-out`,
-          studentName,
-          actionLabel: 'Check-Out',
-          detail: `${activityName} via ${getMethodLabel(entry.checkOutMethod)}`,
-          actionTime,
-          sortTime: actionTime?.getTime() || 0
-        });
-      }
-
-      (entry.changeLog || []).forEach((change, index) => {
-        const actionTime = convertToDate(change.timestamp);
-        items.push({
-          id: `${entry.id}-change-${index}`,
-          studentName,
-          actionLabel: getChangeTypeLabel(change.type),
-          detail: change.description || activityName,
-          actionTime,
-          sortTime: actionTime?.getTime() || 0
-        });
-      });
-
-      return items;
-    })
-    .sort((a, b) => b.sortTime - a.sortTime)
-    .slice(0, 5);
-};
+import { buildActivityItems, convertToDate } from '../../utils/activityFeed';
 
 /**
  * Admin Dashboard Component
@@ -134,7 +41,7 @@ export default function AdminDashboard() {
   }, [currentEvent?.activities]);
 
   const recentActivityItems = useMemo(() => (
-    buildRecentActivityItems(timeEntries, studentNameMap, activityNameMap)
+    buildActivityItems(timeEntries, studentNameMap, activityNameMap, 5)
   ), [timeEntries, studentNameMap, activityNameMap]);
 
 
@@ -215,25 +122,13 @@ export default function AdminDashboard() {
           </div>
 
           <div className="bg-white rounded-lg shadow-md p-6">
-            <h3 className="text-lg font-semibold mb-2">🔔 Recent Activity</h3>
-            {recentActivityItems.length > 0 ? (
-              recentActivityItems.map(item => (
-                <div key={item.id} className="text-sm border-b py-2">
-                  <div className="flex justify-between gap-3">
-                    <span className="font-bold text-gray-800">{item.studentName}</span>
-                    <span className="text-gray-500 whitespace-nowrap">
-                      {formatActivityTime(item.actionTime)}
-                    </span>
-                  </div>
-                  <div className="mt-1 flex justify-between gap-3 text-xs">
-                    <span className="font-semibold text-gray-700">{item.actionLabel}</span>
-                    <span className="text-gray-500 text-right">{item.detail}</span>
-                  </div>
-                </div>
-              ))
-            ) : (
-              <p className="text-gray-500 text-sm">No recent activity</p>
-            )}
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <h3 className="text-lg font-semibold">🔔 Recent Activity</h3>
+              <Link to="/admin/activity" className="text-xs font-black text-primary-700 hover:text-primary-800">
+                View all
+              </Link>
+            </div>
+            <ActivityFeedList items={recentActivityItems} />
           </div>
 
           <div className="bg-white rounded-lg shadow-md p-6">

--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -40,6 +40,7 @@ export default function Header({
 
   const operationsNav = [
     { path: '/admin', label: 'Dashboard', exact: true },
+    { path: '/admin/activity', label: 'Activity' },
     { path: '/admin/students', label: 'Students' },
     { path: '/admin/daily-review', label: 'Daily Review' },
   ];

--- a/frontend/src/pages/ActivityPage.jsx
+++ b/frontend/src/pages/ActivityPage.jsx
@@ -1,0 +1,209 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { collection, onSnapshot } from 'firebase/firestore';
+import ActivityFeedList from '../components/ActivityFeed/ActivityFeedList';
+import Button from '../components/common/Button';
+import Input from '../components/common/Input';
+import { useEvent } from '../contexts/EventContext';
+import { useTimeEntries } from '../hooks/useTimeEntries';
+import { db } from '../utils/firebase';
+import { buildActivityItems } from '../utils/activityFeed';
+
+const PAGE_SIZE = 25;
+
+export default function ActivityPage() {
+  const { currentEvent } = useEvent();
+  const [students, setStudents] = useState([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [activityFilter, setActivityFilter] = useState('all');
+  const [actionFilter, setActionFilter] = useState('all');
+  const [currentPage, setCurrentPage] = useState(1);
+  const { timeEntries, loading } = useTimeEntries({
+    eventId: currentEvent?.id,
+    date: null,
+    realtime: true
+  });
+
+  useEffect(() => {
+    const unsubscribe = onSnapshot(collection(db, 'students'), (snapshot) => {
+      setStudents(snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })));
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const studentNameMap = useMemo(() => {
+    const map = {};
+    students.forEach(student => {
+      map[student.id] = [student.firstName, student.lastName].filter(Boolean).join(' ') || student.firstName || 'Student';
+    });
+    return map;
+  }, [students]);
+
+  const activityNameMap = useMemo(() => {
+    const map = {};
+    (currentEvent?.activities || []).forEach(activity => {
+      map[activity.id] = activity.name;
+    });
+    return map;
+  }, [currentEvent?.activities]);
+
+  const activityItems = useMemo(() => (
+    buildActivityItems(timeEntries, studentNameMap, activityNameMap)
+  ), [timeEntries, studentNameMap, activityNameMap]);
+
+  const actionOptions = useMemo(() => (
+    [...new Set(activityItems.map(item => item.actionLabel))].sort()
+  ), [activityItems]);
+
+  const filteredItems = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return activityItems.filter(item => {
+      const matchesSearch = !normalizedSearch || [
+        item.studentName,
+        item.actionLabel,
+        item.detail
+      ].some(value => value.toLowerCase().includes(normalizedSearch));
+      const matchesActivity = activityFilter === 'all' || item.activityId === activityFilter;
+      const matchesAction = actionFilter === 'all' || item.actionLabel === actionFilter;
+
+      return matchesSearch && matchesActivity && matchesAction;
+    });
+  }, [activityItems, searchTerm, activityFilter, actionFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE));
+  const normalizedPage = Math.min(currentPage, totalPages);
+  const pageStartIndex = (normalizedPage - 1) * PAGE_SIZE;
+  const pageItems = filteredItems.slice(pageStartIndex, pageStartIndex + PAGE_SIZE);
+  const pageStart = filteredItems.length === 0 ? 0 : pageStartIndex + 1;
+  const pageEnd = Math.min(pageStartIndex + PAGE_SIZE, filteredItems.length);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchTerm, activityFilter, actionFilter]);
+
+  useEffect(() => {
+    setCurrentPage(page => Math.min(page, totalPages));
+  }, [totalPages]);
+
+  const clearFilters = () => {
+    setSearchTerm('');
+    setActivityFilter('all');
+    setActionFilter('all');
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <h1 className="text-3xl font-black tracking-tight text-gray-900">Activity</h1>
+          <p className="mt-1 text-sm font-medium text-gray-500">
+            {currentEvent?.name ? `All activity for ${currentEvent.name}` : 'All activity for the selected event'}
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+          {loading ? (
+            <p className="text-sm text-gray-500">Loading activity...</p>
+          ) : (
+            <>
+              <div className="mb-5 grid gap-3 md:grid-cols-[minmax(0,1fr)_180px_180px_auto]">
+                <Input
+                  label="Search"
+                  aria-label="Search activity"
+                  value={searchTerm}
+                  onChange={(event) => setSearchTerm(event.target.value)}
+                  placeholder="Student, action, or detail"
+                />
+
+                <div>
+                  <label htmlFor="activity-filter" className="mb-1 block text-sm font-medium text-gray-700">
+                    Activity
+                  </label>
+                  <select
+                    id="activity-filter"
+                    value={activityFilter}
+                    onChange={(event) => setActivityFilter(event.target.value)}
+                    className="input-field"
+                  >
+                    <option value="all">All activities</option>
+                    {(currentEvent?.activities || []).map(activity => (
+                      <option key={activity.id} value={activity.id}>
+                        {activity.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label htmlFor="action-filter" className="mb-1 block text-sm font-medium text-gray-700">
+                    Action
+                  </label>
+                  <select
+                    id="action-filter"
+                    value={actionFilter}
+                    onChange={(event) => setActionFilter(event.target.value)}
+                    className="input-field"
+                  >
+                    <option value="all">All actions</option>
+                    {actionOptions.map(action => (
+                      <option key={action} value={action}>
+                        {action}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="flex items-end">
+                  <Button type="button" variant="secondary" onClick={clearFilters} className="w-full">
+                    Clear
+                  </Button>
+                </div>
+              </div>
+
+              <div className="mb-3 flex flex-col gap-2 border-b border-gray-100 pb-3 text-sm text-gray-500 sm:flex-row sm:items-center sm:justify-between">
+                <span>
+                  Showing {pageStart}-{pageEnd} of {filteredItems.length} activity items
+                </span>
+                <span>
+                  Page {normalizedPage} of {totalPages}
+                </span>
+              </div>
+
+              <ActivityFeedList
+                items={pageItems}
+                emptyMessage="No activity matches these filters"
+                timestampFormat="datetime"
+              />
+
+              {filteredItems.length > PAGE_SIZE && (
+                <div className="mt-5 flex items-center justify-between gap-3 border-t border-gray-100 pt-4">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    disabled={normalizedPage === 1}
+                    onClick={() => setCurrentPage(page => Math.max(1, page - 1))}
+                  >
+                    Previous
+                  </Button>
+                  <span className="text-sm font-medium text-gray-500">
+                    {pageStart}-{pageEnd} of {filteredItems.length}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    disabled={normalizedPage === totalPages}
+                    onClick={() => setCurrentPage(page => Math.min(totalPages, page + 1))}
+                  >
+                    Next
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ActivityPage.test.jsx
+++ b/frontend/src/pages/ActivityPage.test.jsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ActivityPage from './ActivityPage';
+
+const mockStudents = [
+  { id: 'student1', firstName: 'Alice', lastName: 'Adams' },
+  { id: 'student2', firstName: 'Bob', lastName: 'Brown' },
+];
+
+let mockTimeEntries = [];
+let lastTimeEntryOptions;
+
+vi.mock('../utils/firebase', () => ({ db: {} }));
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn((db, path) => ({ _collPath: path })),
+  onSnapshot: vi.fn((ref, callback) => {
+    if (ref?._collPath === 'students') {
+      queueMicrotask(() => callback({
+        docs: mockStudents.map(student => ({
+          id: student.id,
+          data: () => student
+        }))
+      }));
+    }
+
+    return vi.fn();
+  })
+}));
+
+vi.mock('../contexts/EventContext', () => ({
+  useEvent: () => ({
+    currentEvent: {
+      id: 'event1',
+      name: 'VBS 2026',
+      activities: [
+        { id: 'activity1', name: 'Morning Session' },
+        { id: 'activity2', name: 'Afternoon Session' },
+      ]
+    }
+  })
+}));
+
+vi.mock('../hooks/useTimeEntries', () => ({
+  useTimeEntries: (options) => {
+    lastTimeEntryOptions = options;
+    return {
+      timeEntries: mockTimeEntries,
+      loading: false
+    };
+  }
+}));
+
+describe('ActivityPage', () => {
+  beforeEach(() => {
+    mockTimeEntries = [];
+    lastTimeEntryOptions = undefined;
+  });
+
+  it('loads all activity for the selected event', async () => {
+    mockTimeEntries = [
+      {
+        id: 'entry1',
+        studentId: 'student1',
+        activityId: 'activity1',
+        checkInTime: new Date('2026-06-13T09:00:00'),
+        checkInMethod: 'av_scan',
+      },
+      {
+        id: 'entry2',
+        studentId: 'student2',
+        activityId: 'activity2',
+        checkInTime: new Date('2026-06-14T09:00:00'),
+        checkOutTime: new Date('2026-06-14T12:00:00'),
+        checkInMethod: 'self_scan',
+        checkOutMethod: 'manual',
+      }
+    ];
+
+    render(<ActivityPage />);
+
+    expect(lastTimeEntryOptions).toMatchObject({
+      eventId: 'event1',
+      date: null,
+      realtime: true
+    });
+
+    expect(screen.getByRole('heading', { name: 'Activity' })).toBeInTheDocument();
+    expect(screen.getByText('All activity for VBS 2026')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Adams')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText('Bob Brown')).toHaveLength(2);
+    expect(screen.getByText('Morning Session via AV scan')).toBeInTheDocument();
+    expect(screen.getByText('Afternoon Session via manual')).toBeInTheDocument();
+  });
+
+  it('filters activity by search, activity, and action', async () => {
+    const user = userEvent.setup();
+    mockTimeEntries = [
+      {
+        id: 'entry1',
+        studentId: 'student1',
+        activityId: 'activity1',
+        checkInTime: new Date('2026-06-13T09:00:00'),
+        checkInMethod: 'av_scan',
+      },
+      {
+        id: 'entry2',
+        studentId: 'student2',
+        activityId: 'activity2',
+        checkInTime: new Date('2026-06-14T09:00:00'),
+        checkOutTime: new Date('2026-06-14T12:00:00'),
+        checkInMethod: 'self_scan',
+        checkOutMethod: 'manual',
+      }
+    ];
+
+    render(<ActivityPage />);
+
+    await screen.findByText('Alice Adams');
+    expect(screen.getByText('Showing 1-3 of 3 activity items')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Search activity'), 'Alice');
+    expect(screen.getByText('Showing 1-1 of 1 activity items')).toBeInTheDocument();
+    expect(screen.getByText('Alice Adams')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Brown')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+    await user.selectOptions(screen.getByLabelText('Activity'), 'activity2');
+    expect(screen.getByText('Showing 1-2 of 2 activity items')).toBeInTheDocument();
+    expect(screen.queryByText('Alice Adams')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Bob Brown')).toHaveLength(2);
+
+    await user.selectOptions(screen.getByLabelText('Action'), 'Check-Out');
+    expect(screen.getByText('Showing 1-1 of 1 activity items')).toBeInTheDocument();
+    const feed = screen.getByRole('list', { name: 'Activity feed' });
+    expect(within(feed).getByText('Check-Out')).toBeInTheDocument();
+    expect(within(feed).queryByText('Check-In')).not.toBeInTheDocument();
+  });
+
+  it('paginates long activity lists', async () => {
+    const user = userEvent.setup();
+    mockTimeEntries = Array.from({ length: 30 }, (_, index) => ({
+      id: `entry-${index}`,
+      studentId: 'student1',
+      activityId: 'activity1',
+      checkInTime: new Date(`2026-06-14T09:${String(index).padStart(2, '0')}:00`),
+      checkInMethod: 'av_scan',
+    }));
+
+    render(<ActivityPage />);
+
+    await screen.findByText('Showing 1-25 of 30 activity items');
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(screen.getByText('Showing 26-30 of 30 activity items')).toBeInTheDocument();
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+});

--- a/frontend/src/utils/activityFeed.js
+++ b/frontend/src/utils/activityFeed.js
@@ -1,0 +1,105 @@
+export const convertToDate = (timeValue) => {
+  if (!timeValue) return null;
+  if (timeValue instanceof Date) return timeValue;
+  if (typeof timeValue.toDate === 'function') return timeValue.toDate();
+  return new Date(timeValue);
+};
+
+export const formatActivityTime = (timeValue) => {
+  const date = convertToDate(timeValue);
+  return date && !Number.isNaN(date.getTime()) ? date.toLocaleTimeString() : '--';
+};
+
+export const formatActivityDateTime = (timeValue) => {
+  const date = convertToDate(timeValue);
+  return date && !Number.isNaN(date.getTime()) ? date.toLocaleString() : '--';
+};
+
+const getMethodLabel = (method) => {
+  if (method === 'manual') return 'manual';
+  if (method === 'self_scan') return 'self-scan';
+  if (method === 'av_scan') return 'AV scan';
+  return 'scan';
+};
+
+const getChangeTypeLabel = (type) => {
+  switch (type) {
+    case 'void':
+      return 'Voided';
+    case 'restore':
+      return 'Restored';
+    case 'force_checkout':
+    case 'bulk_force_checkout':
+      return 'Forced Check-Out';
+    case 'edit':
+    default:
+      return 'Modified';
+  }
+};
+
+export const buildActivityItems = (timeEntries, studentNameMap, activityNameMap, limit) => {
+  const items = timeEntries
+    .flatMap(entry => {
+      const studentName = studentNameMap[entry.studentId] || 'Student';
+      const activityName = activityNameMap[entry.activityId] || 'Activity';
+      const entryItems = [];
+      const isManualEntry = entry.entry_source === 'manual' || (
+        entry.checkInMethod === 'manual' && entry.checkOutMethod === 'manual'
+      );
+
+      if (isManualEntry) {
+        const actionTime = convertToDate(entry.modifiedAt || entry.createdAt || entry.checkInTime);
+        entryItems.push({
+          id: `${entry.id}-manual-entry`,
+          studentName,
+          activityId: entry.activityId,
+          actionLabel: 'Manual Entry',
+          detail: `${activityName} logged`,
+          actionTime,
+          sortTime: actionTime?.getTime() || 0
+        });
+      } else if (entry.checkInTime) {
+        const actionTime = convertToDate(entry.checkInTime);
+        entryItems.push({
+          id: `${entry.id}-check-in`,
+          studentName,
+          activityId: entry.activityId,
+          actionLabel: 'Check-In',
+          detail: `${activityName} via ${getMethodLabel(entry.checkInMethod)}`,
+          actionTime,
+          sortTime: actionTime?.getTime() || 0
+        });
+      }
+
+      if (!isManualEntry && entry.checkOutTime) {
+        const actionTime = convertToDate(entry.checkOutTime);
+        entryItems.push({
+          id: `${entry.id}-check-out`,
+          studentName,
+          activityId: entry.activityId,
+          actionLabel: 'Check-Out',
+          detail: `${activityName} via ${getMethodLabel(entry.checkOutMethod)}`,
+          actionTime,
+          sortTime: actionTime?.getTime() || 0
+        });
+      }
+
+      (entry.changeLog || []).forEach((change, index) => {
+        const actionTime = convertToDate(change.timestamp);
+        entryItems.push({
+          id: `${entry.id}-change-${index}`,
+          studentName,
+          activityId: entry.activityId,
+          actionLabel: getChangeTypeLabel(change.type),
+          detail: change.description || activityName,
+          actionTime,
+          sortTime: actionTime?.getTime() || 0
+        });
+      });
+
+      return entryItems;
+    })
+    .sort((a, b) => b.sortTime - a.sortTime);
+
+  return typeof limit === 'number' ? items.slice(0, limit) : items;
+};


### PR DESCRIPTION
## Summary
- add an event-scoped Activity page with search, activity/action filters, and pagination
- move dashboard recent activity rendering into reusable feed utilities/components
- add Dashboard "View all" link and Activity sidebar navigation

## Tests
- npm test -- ActivityPage
- npm test -- AdminDashboard ActivityPage
- npm run build
- npm test