### PR TITLE
Fix Daily Review hour calculations

### DIFF
--- a/frontend/src/components/DailyReview/DailyReview.test.jsx
+++ b/frontend/src/components/DailyReview/DailyReview.test.jsx
@@ -70,6 +70,15 @@ vi.mock('../../contexts/EventContext', () => ({
 
 // Mock hourCalculations
 vi.mock('../../utils/hourCalculations', () => ({
+  calculateHours: (checkIn, checkOut) => {
+    const minutes = Math.floor((checkOut - checkIn) / 1000 / 60);
+    const hours = minutes / 60;
+    return {
+      rounded: Math.round(hours * 4) / 4,
+      raw: hours,
+      minutes
+    };
+  },
   formatTime: (date) => {
     if (!date) return '--';
     const d = new Date(date);
@@ -576,6 +585,32 @@ describe('DailyReview', () => {
 
       await waitFor(() => {
         expect(getDesktopRowNames()).toEqual(['Zephyr, Zoe', 'Adams, Amy']);
+      });
+    });
+
+    it('should calculate displayed hours from timestamps instead of stored half-hour values', async () => {
+      mockFirestoreData.students = [
+        { id: 'student1', firstName: 'Amy', lastName: 'Adams' }
+      ];
+      mockFirestoreData.timeEntries = [
+        {
+          id: 'entry1',
+          eventId: 'event123',
+          studentId: 'student1',
+          activityId: 'activity1',
+          date: '2026-01-31',
+          checkInTime: new Date('2026-01-31T08:00:00'),
+          checkOutTime: new Date('2026-01-31T11:15:00'),
+          hoursWorked: 3.5,
+          flags: []
+        }
+      ];
+
+      renderWithRouter(<DailyReview />);
+
+      await waitFor(() => {
+        const table = screen.getByRole('table', { name: 'Daily student activity review' });
+        expect(within(table).getByText('Hours: 3.25 hrs')).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/components/DailyReview/index.jsx
+++ b/frontend/src/components/DailyReview/index.jsx
@@ -4,7 +4,7 @@ import { db, functions } from '../../utils/firebase';
 import { collection, onSnapshot, query, where, doc, updateDoc } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 import { useEvent } from '../../contexts/EventContext';
-import { formatTime, formatHours, getTodayDateString, formatDate } from '../../utils/hourCalculations';
+import { calculateHours, formatTime, formatHours, getTodayDateString, formatDate } from '../../utils/hourCalculations';
 import { buildEditChangeDescription } from '../../utils/changeDescriptions';
 import { printInNewWindow, createPrintDocument } from '../../utils/printUtils';
 import Button from '../common/Button';
@@ -64,6 +64,14 @@ const compareStudentName = (leftStudent, rightStudent) => {
   const lastNameCompare = (leftStudent?.lastName || '').localeCompare(rightStudent?.lastName || '', undefined, { sensitivity: 'base' });
   if (lastNameCompare !== 0) return lastNameCompare;
   return (leftStudent?.firstName || '').localeCompare(rightStudent?.firstName || '', undefined, { sensitivity: 'base' });
+};
+
+const getCreditedHours = (entry) => {
+  if (entry?.checkInTime && entry?.checkOutTime) {
+    return calculateHours(new Date(entry.checkInTime), new Date(entry.checkOutTime)).rounded;
+  }
+
+  return entry?.hoursWorked ?? null;
 };
 
 /**
@@ -287,6 +295,7 @@ export default function DailyReview() {
   const entryRows = useMemo(() => {
     return timeEntries.map(entry => ({
       ...entry,
+      hoursWorked: getCreditedHours(entry),
       student: studentMap[entry.studentId] || { firstName: 'Unknown', lastName: 'Student' },
       activity: activityMap[entry.activityId] || { id: entry.activityId, name: 'Unknown Activity', endTime: '15:00' }
     }));
@@ -724,7 +733,7 @@ export default function DailyReview() {
       if (checkInTime && checkOutTime) {
         const minutes = Math.floor((checkOutTime - checkInTime) / 1000 / 60);
         rawMinutes = minutes;
-        hoursWorked = Math.round((minutes / 60) * 2) / 2; // Round to nearest 0.5
+        hoursWorked = calculateHours(checkInTime, checkOutTime).rounded;
       }
 
       // Build smart change description (only includes fields that actually changed)
@@ -1816,9 +1825,7 @@ export default function DailyReview() {
                     {(() => {
                       const checkIn = new Date(editModal.checkInTime);
                       const checkOut = new Date(editModal.checkOutTime);
-                      const minutes = Math.floor((checkOut - checkIn) / 1000 / 60);
-                      const hours = Math.round((minutes / 60) * 2) / 2;
-                      return formatHours(hours);
+                      return formatHours(calculateHours(checkIn, checkOut).rounded);
                     })()}
                   </span>
                 </p>

--- a/frontend/src/utils/hourCalculations.js
+++ b/frontend/src/utils/hourCalculations.js
@@ -1,11 +1,7 @@
 import { format, parse } from 'date-fns';
 
 /**
- * Calculate hours worked and round to nearest 0.5 hour
- * Per PRD Section 3.4.1:
- * - 0-14 minutes = round down
- * - 15-44 minutes = round to 0.5
- * - 45-59 minutes = round up to next hour
+ * Calculate hours worked and round to nearest 0.25 hour.
  *
  * @param {Date} checkIn - Check-in timestamp
  * @param {Date} checkOut - Check-out timestamp
@@ -15,11 +11,11 @@ export function calculateHours(checkIn, checkOut) {
   const minutes = Math.floor((checkOut - checkIn) / 1000 / 60);
   const hours = minutes / 60;
 
-  // Round to nearest 0.5
-  const rounded = Math.round(hours * 2) / 2;
+  // Round to nearest quarter hour to match student detail and reports.
+  const rounded = Math.round(hours * 4) / 4;
 
   return {
-    rounded,          // 6.5
+    rounded,          // 6.25
     raw: hours,       // 6.216666...
     minutes           // 373
   };
@@ -92,7 +88,7 @@ export function formatHours(hours) {
   if (hours === null || hours === undefined) {
     return '--';
   }
-  return `${hours.toFixed(1)} ${hours === 1 ? 'hour' : 'hours'}`;
+  return `${hours.toFixed(2)} ${hours === 1 ? 'hour' : 'hours'}`;
 }
 
 /**

--- a/frontend/src/utils/hourCalculations.test.js
+++ b/frontend/src/utils/hourCalculations.test.js
@@ -22,31 +22,31 @@ describe('hourCalculations', () => {
       expect(result.rounded).toBe(6);
     });
 
-    it('should round down for 0-14 minutes (6h 13m -> 6.0)', () => {
+    it('should round to the nearest quarter hour (6h 13m -> 6.25)', () => {
       const checkIn = new Date('2026-06-15T09:02:00');
       const checkOut = new Date('2026-06-15T15:15:00');
       const result = calculateHours(checkIn, checkOut);
 
       expect(result.minutes).toBe(373); // 6h 13m
-      expect(result.rounded).toBe(6.0);
+      expect(result.rounded).toBe(6.25);
     });
 
-    it('should round to 0.5 for 15-44 minutes (6h 16m -> 6.5)', () => {
+    it('should round to the nearest quarter hour (6h 16m -> 6.25)', () => {
       const checkIn = new Date('2026-06-15T09:02:00');
       const checkOut = new Date('2026-06-15T15:18:00');
       const result = calculateHours(checkIn, checkOut);
 
       expect(result.minutes).toBe(376); // 6h 16m
-      expect(result.rounded).toBe(6.5);
+      expect(result.rounded).toBe(6.25);
     });
 
-    it('should round up for 45-59 minutes (6h 47m -> 7.0)', () => {
+    it('should round to the nearest quarter hour (6h 47m -> 6.75)', () => {
       const checkIn = new Date('2026-06-15T09:00:00');
       const checkOut = new Date('2026-06-15T15:47:00');
       const result = calculateHours(checkIn, checkOut);
 
       expect(result.minutes).toBe(407); // 6h 47m
-      expect(result.rounded).toBe(7.0);
+      expect(result.rounded).toBe(6.75);
     });
 
     it('should handle 7h 30m -> 7.5 hours', () => {
@@ -175,15 +175,19 @@ describe('hourCalculations', () => {
 
   describe('formatHours', () => {
     it('should format hours with decimal', () => {
-      expect(formatHours(6.5)).toBe('6.5 hours');
+      expect(formatHours(6.5)).toBe('6.50 hours');
     });
 
     it('should use singular "hour" for 1 hour', () => {
-      expect(formatHours(1)).toBe('1.0 hour');
+      expect(formatHours(1)).toBe('1.00 hour');
     });
 
     it('should handle whole numbers', () => {
-      expect(formatHours(7)).toBe('7.0 hours');
+      expect(formatHours(7)).toBe('7.00 hours');
+    });
+
+    it('should preserve quarter hours', () => {
+      expect(formatHours(3.25)).toBe('3.25 hours');
     });
 
     it('should return "--" for null', () => {
@@ -195,7 +199,7 @@ describe('hourCalculations', () => {
     });
 
     it('should handle zero hours', () => {
-      expect(formatHours(0)).toBe('0.0 hours');
+      expect(formatHours(0)).toBe('0.00 hours');
     });
   });
 

--- a/functions/src/checkHoursLogged.js
+++ b/functions/src/checkHoursLogged.js
@@ -55,22 +55,18 @@ function timestampToIso(value) {
 }
 
 function getHours(entry) {
-  if (typeof entry.hoursWorked === 'number') {
-    return entry.hoursWorked;
+  if (entry.checkInTime && entry.checkOutTime) {
+    const checkInMs = typeof entry.checkInTime.toMillis === 'function'
+      ? entry.checkInTime.toMillis()
+      : entry.checkInTime.seconds * 1000;
+    const checkOutMs = typeof entry.checkOutTime.toMillis === 'function'
+      ? entry.checkOutTime.toMillis()
+      : entry.checkOutTime.seconds * 1000;
+    const hours = (checkOutMs - checkInMs) / 1000 / 60 / 60;
+    return Math.round(hours * 4) / 4;
   }
 
-  if (!entry.checkInTime || !entry.checkOutTime) {
-    return 0;
-  }
-
-  const checkInMs = typeof entry.checkInTime.toMillis === 'function'
-    ? entry.checkInTime.toMillis()
-    : entry.checkInTime.seconds * 1000;
-  const checkOutMs = typeof entry.checkOutTime.toMillis === 'function'
-    ? entry.checkOutTime.toMillis()
-    : entry.checkOutTime.seconds * 1000;
-  const hours = (checkOutMs - checkInMs) / 1000 / 60 / 60;
-  return Math.round(hours * 4) / 4;
+  return typeof entry.hoursWorked === 'number' ? entry.hoursWorked : 0;
 }
 
 function publicStudentProfile(student, studentId) {

--- a/functions/test/checkHoursLogged.test.js
+++ b/functions/test/checkHoursLogged.test.js
@@ -162,6 +162,33 @@ describe('checkHoursLogged Cloud Function', () => {
     expect(result.totalHours).toBe(5);
   });
 
+  it('calculates credited hours from timestamps before falling back to stored hoursWorked', async () => {
+    mockGet.mockResolvedValueOnce({
+      docs: [
+        {
+          id: 'entry1',
+          data: () => ({
+            studentId: 'student123',
+            eventId: 'event456',
+            activityId: 'work-hours',
+            date: '2026-06-15',
+            checkInTime: makeTimestamp('2026-06-15T09:00:00-04:00'),
+            checkOutTime: makeTimestamp('2026-06-15T12:15:00-04:00'),
+            hoursWorked: 3.5,
+            isVoided: false,
+          }),
+        },
+      ],
+    });
+
+    const result = await checkHoursLogged({
+      data: { qrData: generateQRData('student123', 'event456') },
+    });
+
+    expect(result.totalHours).toBe(3.25);
+    expect(result.events[0].entries[0].hours).toBe(3.25);
+  });
+
   it('rejects QR data with an invalid checksum', async () => {
     await expect(checkHoursLogged({
       data: { qrData: 'student123|event456|bad' },


### PR DESCRIPTION
## Summary
- calculate Daily Review credited hours from timestamps using the shared quarter-hour helper
- format shared frontend hours with two decimals so quarter-hour values display accurately
- calculate public hour lookup/report hours from timestamps before falling back to stored hoursWorked

## Tests
- npm test -- src/utils/hourCalculations.test.js src/components/DailyReview/DailyReview.test.jsx
- npm test -- checkHoursLogged.test.js

Closes #91