### PR TITLE
Show school form on hours checker

### DIFF
--- a/frontend/src/pages/CheckHoursPage.jsx
+++ b/frontend/src/pages/CheckHoursPage.jsx
@@ -1,8 +1,10 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { httpsCallable } from 'firebase/functions';
-import { functions } from '../utils/firebase';
+import { collection, doc, onSnapshot } from 'firebase/firestore';
+import { db, functions } from '../utils/firebase';
 import useQRScanner from '../hooks/useQRScanner';
 import Spinner from '../components/common/Spinner';
+import { getEffectivePdfTemplate } from '../utils/pdfTemplateUtils';
 
 const qrReaderId = 'hours-qr-reader';
 
@@ -39,12 +41,33 @@ export default function CheckHoursPage() {
   const [selectedEventId, setSelectedEventId] = useState(null);
   const [manualQrData, setManualQrData] = useState('');
   const [status, setStatus] = useState({ type: 'idle', message: '' });
+  const [pdfTemplates, setPdfTemplates] = useState([]);
+  const [defaultTemplateId, setDefaultTemplateId] = useState(null);
   const lookupInFlight = useRef(false);
+
+  useEffect(() => {
+    const unsubTemplates = onSnapshot(collection(db, 'pdfTemplates'), (snapshot) => {
+      setPdfTemplates(snapshot.docs.map((templateDoc) => ({ id: templateDoc.id, ...templateDoc.data() })));
+    });
+    const unsubDefaults = onSnapshot(doc(db, 'settings', 'pdfDefaults'), (snapshot) => {
+      setDefaultTemplateId(snapshot.exists() ? snapshot.data().defaultTemplateId : null);
+    });
+
+    return () => {
+      unsubTemplates();
+      unsubDefaults();
+    };
+  }, []);
 
   const selectedEvent = useMemo(() => {
     if (!lookup?.events?.length) return null;
     return lookup.events.find((event) => event.id === selectedEventId) || null;
   }, [lookup, selectedEventId]);
+
+  const effectiveTemplate = useMemo(() => {
+    if (!lookup?.student) return null;
+    return getEffectivePdfTemplate(lookup.student, pdfTemplates, defaultTemplateId);
+  }, [lookup, pdfTemplates, defaultTemplateId]);
 
   const loadHours = async (qrData) => {
     if (!qrData || lookupInFlight.current) return;
@@ -173,7 +196,7 @@ export default function CheckHoursPage() {
               <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                 <div>
                   <h2 className="text-2xl font-black text-gray-900">{lookup.student.fullName || 'Volunteer'}</h2>
-                  <dl className="mt-3 grid gap-3 text-sm text-gray-600 sm:grid-cols-3">
+                  <dl className="mt-3 grid gap-3 text-sm text-gray-600 sm:grid-cols-4">
                     <div>
                       <dt className="font-bold text-gray-900">School</dt>
                       <dd>{lookup.student.schoolName || 'Not listed'}</dd>
@@ -185,6 +208,10 @@ export default function CheckHoursPage() {
                     <div>
                       <dt className="font-bold text-gray-900">All Credited Hours</dt>
                       <dd>{formatHours(lookup.totalHours)}</dd>
+                    </div>
+                    <div>
+                      <dt className="font-bold text-gray-900">School Form</dt>
+                      <dd>{effectiveTemplate?.name || 'No form configured'}</dd>
                     </div>
                   </dl>
                 </div>

--- a/frontend/src/pages/CheckHoursPage.test.jsx
+++ b/frontend/src/pages/CheckHoursPage.test.jsx
@@ -3,13 +3,21 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import CheckHoursPage from './CheckHoursPage';
 
 const mockCheckHoursLogged = vi.fn();
+const mockOnSnapshot = vi.fn();
 
 vi.mock('../utils/firebase', () => ({
+  db: {},
   functions: {},
 }));
 
 vi.mock('firebase/functions', () => ({
   httpsCallable: vi.fn(() => mockCheckHoursLogged),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn((db, name) => ({ type: 'collection', name })),
+  doc: vi.fn((db, collectionName, id) => ({ type: 'doc', collectionName, id })),
+  onSnapshot: (...args) => mockOnSnapshot(...args),
 }));
 
 vi.mock('html5-qrcode', () => ({
@@ -24,6 +32,28 @@ vi.mock('html5-qrcode', () => ({
 describe('CheckHoursPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockOnSnapshot.mockImplementation((ref, callback) => {
+      if (ref.type === 'collection' && ref.name === 'pdfTemplates') {
+        callback({
+          docs: [
+            {
+              id: 'central-template',
+              data: () => ({ name: 'Central High School Form', fileName: 'central.pdf' }),
+            },
+            {
+              id: 'default-template',
+              data: () => ({ name: 'Default School Form', fileName: 'default.pdf' }),
+            },
+          ],
+        });
+      } else {
+        callback({
+          exists: () => true,
+          data: () => ({ defaultTemplateId: 'default-template' }),
+        });
+      }
+      return vi.fn();
+    });
     mockCheckHoursLogged.mockResolvedValue({
       data: {
         success: true,
@@ -35,6 +65,7 @@ describe('CheckHoursPage', () => {
           fullName: 'Jane Smith',
           schoolName: 'Central High',
           gradeLevel: '10',
+          pdfTemplateId: '',
         },
         totalHours: 5,
         events: [
@@ -93,6 +124,43 @@ describe('CheckHoursPage', () => {
     expect(screen.getByText('Central High')).toBeInTheDocument();
     expect(screen.getByText('All Credited Hours')).toBeInTheDocument();
     expect(screen.getByText('5.00 hours')).toBeInTheDocument();
+    expect(screen.getByText('School Form')).toBeInTheDocument();
+    expect(screen.getByText('Central High School Form')).toBeInTheDocument();
+  });
+
+  it('shows the assigned school form when the student has a template override', async () => {
+    mockCheckHoursLogged.mockResolvedValueOnce({
+      data: {
+        success: true,
+        scannedEventId: null,
+        student: {
+          id: 'student1',
+          firstName: 'Jane',
+          lastName: 'Smith',
+          fullName: 'Jane Smith',
+          schoolName: 'Central High',
+          gradeLevel: '10',
+          pdfTemplateId: 'default-template',
+        },
+        totalHours: 0,
+        events: [],
+      },
+    });
+
+    render(<CheckHoursPage />);
+
+    act(() => {
+      fireEvent.change(screen.getByLabelText(/QR code text/i), {
+        target: { value: 'student1' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Default School Form')).toBeInTheDocument();
+    });
   });
 
   it('asks which event to inspect before showing event details', async () => {

--- a/frontend/src/pages/EventStudentsPage.jsx
+++ b/frontend/src/pages/EventStudentsPage.jsx
@@ -16,51 +16,13 @@ import {
     writeBatch,
 } from 'firebase/firestore';
 import { ref, getDownloadURL } from 'firebase/storage';
-import { generateFilledPdf, mergePdfs, openPdfForPrinting } from '../utils/pdfTemplateUtils';
+import { generateFilledPdf, getEffectivePdfTemplate, mergePdfs, openPdfForPrinting } from '../utils/pdfTemplateUtils';
 import { useAuth } from '../contexts/AuthContext';
 import { useEvent } from '../contexts/EventContext';
 import Button from '../components/common/Button';
 import Spinner from '../components/common/Spinner';
 import PrintableBadge from '../components/common/PrintableBadge';
 import { GRADE_LEVEL_OPTIONS } from '../utils/grades';
-
-const normalizeTemplateText = (value = '') =>
-    value.toLowerCase().replace(/[^a-z0-9]/g, '');
-
-const SCHOOL_TEMPLATE_ALIASES = [
-    { school: ['bishopmoore', 'bishopmoorecatholic'], template: ['bishopmoore'] },
-    { school: ['thefirstacademy', 'firstacademy', 'tfa'], template: ['thefirstacademy', 'firstacademy', 'tfa'] },
-];
-
-const findTemplateForSchool = (schoolName, templates) => {
-    const normalizedSchool = normalizeTemplateText(schoolName);
-    if (!normalizedSchool) return null;
-
-    const templateMatches = (template, values) => {
-        const normalizedTemplate = normalizeTemplateText(`${template.name || ''} ${template.fileName || ''}`);
-        return values.some(value => normalizedTemplate.includes(value));
-    };
-
-    const exactMatch = templates.find(template => {
-        const normalizedTemplate = normalizeTemplateText(`${template.name || ''} ${template.fileName || ''}`);
-        return normalizedTemplate &&
-            (normalizedTemplate.includes(normalizedSchool) || normalizedSchool.includes(normalizedTemplate));
-    });
-    if (exactMatch) return exactMatch;
-
-    const alias = SCHOOL_TEMPLATE_ALIASES.find(item =>
-        item.school.some(value => normalizedSchool.includes(value))
-    );
-    if (alias) {
-        const aliasMatch = templates.find(template => templateMatches(template, alias.template));
-        if (aliasMatch) return aliasMatch;
-    }
-
-    const ocpsTemplate = templates.find(template => templateMatches(template, ['ocps']));
-    if (ocpsTemplate) return ocpsTemplate;
-
-    return null;
-};
 
 export default function EventStudentsPage() {
     const { eventId: paramEventId } = useParams();
@@ -387,14 +349,7 @@ export default function EventStudentsPage() {
     };
 
     const getEffectiveTemplate = (student) => {
-        if (student.pdfTemplateId) {
-            return pdfTemplates.find(template => template.id === student.pdfTemplateId) || null;
-        }
-
-        const schoolTemplate = findTemplateForSchool(student.schoolName, pdfTemplates);
-        if (schoolTemplate) return schoolTemplate;
-
-        return defaultTemplateId ? pdfTemplates.find(template => template.id === defaultTemplateId) || null : null;
+        return getEffectivePdfTemplate(student, pdfTemplates, defaultTemplateId);
     };
 
     const handlePrintBadges = () => {

--- a/frontend/src/pages/EventStudentsPage.test.jsx
+++ b/frontend/src/pages/EventStudentsPage.test.jsx
@@ -13,6 +13,26 @@ vi.mock('firebase/storage', () => ({
 
 vi.mock('../utils/pdfTemplateUtils', () => ({
     generateFilledPdf: vi.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
+    getEffectivePdfTemplate: vi.fn((student = {}, templates = [], defaultTemplateId = null) => {
+        if (student.pdfTemplateId) {
+            return templates.find(template => template.id === student.pdfTemplateId) || null;
+        }
+
+        const normalizedSchool = (student.schoolName || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+        const schoolTemplate = templates.find(template => {
+            const normalizedTemplate = `${template.name || ''} ${template.fileName || ''}`.toLowerCase().replace(/[^a-z0-9]/g, '');
+            return normalizedTemplate &&
+                (normalizedTemplate.includes(normalizedSchool) || normalizedSchool.includes(normalizedTemplate));
+        });
+        if (schoolTemplate) return schoolTemplate;
+
+        const ocpsTemplate = templates.find(template =>
+            `${template.name || ''} ${template.fileName || ''}`.toLowerCase().replace(/[^a-z0-9]/g, '').includes('ocps')
+        );
+        if (ocpsTemplate) return ocpsTemplate;
+
+        return defaultTemplateId ? templates.find(template => template.id === defaultTemplateId) || null : null;
+    }),
     mergePdfs: vi.fn((arr) => Promise.resolve(arr[0] || new Uint8Array([1, 2, 3]))),
     openPdfForPrinting: vi.fn(),
 }));

--- a/frontend/src/utils/pdfTemplateUtils.js
+++ b/frontend/src/utils/pdfTemplateUtils.js
@@ -2,6 +2,55 @@ import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
 
 const REPORT_TIME_ZONE = 'America/New_York';
 
+export const normalizeTemplateText = (value = '') =>
+  value.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+const SCHOOL_TEMPLATE_ALIASES = [
+  { school: ['bishopmoore', 'bishopmoorecatholic'], template: ['bishopmoore'] },
+  { school: ['thefirstacademy', 'firstacademy', 'tfa'], template: ['thefirstacademy', 'firstacademy', 'tfa'] },
+];
+
+export const findTemplateForSchool = (schoolName, templates = []) => {
+  const normalizedSchool = normalizeTemplateText(schoolName);
+  if (!normalizedSchool) return null;
+
+  const templateMatches = (template, values) => {
+    const normalizedTemplate = normalizeTemplateText(`${template.name || ''} ${template.fileName || ''}`);
+    return values.some(value => normalizedTemplate.includes(value));
+  };
+
+  const exactMatch = templates.find(template => {
+    const normalizedTemplate = normalizeTemplateText(`${template.name || ''} ${template.fileName || ''}`);
+    return normalizedTemplate &&
+      (normalizedTemplate.includes(normalizedSchool) || normalizedSchool.includes(normalizedTemplate));
+  });
+  if (exactMatch) return exactMatch;
+
+  const alias = SCHOOL_TEMPLATE_ALIASES.find(item =>
+    item.school.some(value => normalizedSchool.includes(value))
+  );
+  if (alias) {
+    const aliasMatch = templates.find(template => templateMatches(template, alias.template));
+    if (aliasMatch) return aliasMatch;
+  }
+
+  const ocpsTemplate = templates.find(template => templateMatches(template, ['ocps']));
+  if (ocpsTemplate) return ocpsTemplate;
+
+  return null;
+};
+
+export const getEffectivePdfTemplate = (student = {}, templates = [], defaultTemplateId = null) => {
+  if (student.pdfTemplateId) {
+    return templates.find(template => template.id === student.pdfTemplateId) || null;
+  }
+
+  const schoolTemplate = findTemplateForSchool(student.schoolName, templates);
+  if (schoolTemplate) return schoolTemplate;
+
+  return defaultTemplateId ? templates.find(template => template.id === defaultTemplateId) || null : null;
+};
+
 export function toDateValue(value) {
   if (!value) return null;
   if (value.toDate) return value.toDate();

--- a/functions/src/checkHoursLogged.js
+++ b/functions/src/checkHoursLogged.js
@@ -78,6 +78,7 @@ function publicStudentProfile(student, studentId) {
     schoolName: student.schoolName || '',
     gradeLevel: student.gradeLevel || '',
     gradYear: student.gradYear || '',
+    pdfTemplateId: student.pdfTemplateId || '',
   };
 }
 

--- a/functions/test/checkHoursLogged.test.js
+++ b/functions/test/checkHoursLogged.test.js
@@ -70,6 +70,7 @@ describe('checkHoursLogged Cloud Function', () => {
           lastName: 'Smith',
           schoolName: 'Central High',
           gradeLevel: '10',
+          pdfTemplateId: 'central-template',
           email: 'private@example.com',
         }),
       }),
@@ -144,6 +145,7 @@ describe('checkHoursLogged Cloud Function', () => {
       schoolName: 'Central High',
       gradeLevel: '10',
       gradYear: '',
+      pdfTemplateId: 'central-template',
     });
     expect(result.student.email).toBeUndefined();
     expect(result.totalHours).toBe(5);


### PR DESCRIPTION
## Summary
- show the effective School Form on the /hours student profile
- share the PDF template selection helper with the event student print flow
- include pdfTemplateId in the public hours lookup response so assigned form overrides are honored

## Tests
- npm test -- CheckHoursPage.test.jsx pdfTemplateUtils.test.js
- npm test -- checkHoursLogged.test.js

Closes #108