### PR TITLE
Resolve hours school form server-side

### DIFF
--- a/frontend/src/pages/CheckHoursPage.jsx
+++ b/frontend/src/pages/CheckHoursPage.jsx
@@ -1,10 +1,8 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { httpsCallable } from 'firebase/functions';
-import { collection, doc, onSnapshot } from 'firebase/firestore';
-import { db, functions } from '../utils/firebase';
+import { functions } from '../utils/firebase';
 import useQRScanner from '../hooks/useQRScanner';
 import Spinner from '../components/common/Spinner';
-import { getEffectivePdfTemplate } from '../utils/pdfTemplateUtils';
 
 const qrReaderId = 'hours-qr-reader';
 
@@ -41,33 +39,12 @@ export default function CheckHoursPage() {
   const [selectedEventId, setSelectedEventId] = useState(null);
   const [manualQrData, setManualQrData] = useState('');
   const [status, setStatus] = useState({ type: 'idle', message: '' });
-  const [pdfTemplates, setPdfTemplates] = useState([]);
-  const [defaultTemplateId, setDefaultTemplateId] = useState(null);
   const lookupInFlight = useRef(false);
-
-  useEffect(() => {
-    const unsubTemplates = onSnapshot(collection(db, 'pdfTemplates'), (snapshot) => {
-      setPdfTemplates(snapshot.docs.map((templateDoc) => ({ id: templateDoc.id, ...templateDoc.data() })));
-    });
-    const unsubDefaults = onSnapshot(doc(db, 'settings', 'pdfDefaults'), (snapshot) => {
-      setDefaultTemplateId(snapshot.exists() ? snapshot.data().defaultTemplateId : null);
-    });
-
-    return () => {
-      unsubTemplates();
-      unsubDefaults();
-    };
-  }, []);
 
   const selectedEvent = useMemo(() => {
     if (!lookup?.events?.length) return null;
     return lookup.events.find((event) => event.id === selectedEventId) || null;
   }, [lookup, selectedEventId]);
-
-  const effectiveTemplate = useMemo(() => {
-    if (!lookup?.student) return null;
-    return getEffectivePdfTemplate(lookup.student, pdfTemplates, defaultTemplateId);
-  }, [lookup, pdfTemplates, defaultTemplateId]);
 
   const loadHours = async (qrData) => {
     if (!qrData || lookupInFlight.current) return;
@@ -211,7 +188,7 @@ export default function CheckHoursPage() {
                     </div>
                     <div>
                       <dt className="font-bold text-gray-900">School Form</dt>
-                      <dd>{effectiveTemplate?.name || 'No form configured'}</dd>
+                      <dd>{lookup.schoolForm?.name || 'No form configured'}</dd>
                     </div>
                   </dl>
                 </div>

--- a/frontend/src/pages/CheckHoursPage.test.jsx
+++ b/frontend/src/pages/CheckHoursPage.test.jsx
@@ -3,21 +3,13 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import CheckHoursPage from './CheckHoursPage';
 
 const mockCheckHoursLogged = vi.fn();
-const mockOnSnapshot = vi.fn();
 
 vi.mock('../utils/firebase', () => ({
-  db: {},
   functions: {},
 }));
 
 vi.mock('firebase/functions', () => ({
   httpsCallable: vi.fn(() => mockCheckHoursLogged),
-}));
-
-vi.mock('firebase/firestore', () => ({
-  collection: vi.fn((db, name) => ({ type: 'collection', name })),
-  doc: vi.fn((db, collectionName, id) => ({ type: 'doc', collectionName, id })),
-  onSnapshot: (...args) => mockOnSnapshot(...args),
 }));
 
 vi.mock('html5-qrcode', () => ({
@@ -32,28 +24,6 @@ vi.mock('html5-qrcode', () => ({
 describe('CheckHoursPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockOnSnapshot.mockImplementation((ref, callback) => {
-      if (ref.type === 'collection' && ref.name === 'pdfTemplates') {
-        callback({
-          docs: [
-            {
-              id: 'central-template',
-              data: () => ({ name: 'Central High School Form', fileName: 'central.pdf' }),
-            },
-            {
-              id: 'default-template',
-              data: () => ({ name: 'Default School Form', fileName: 'default.pdf' }),
-            },
-          ],
-        });
-      } else {
-        callback({
-          exists: () => true,
-          data: () => ({ defaultTemplateId: 'default-template' }),
-        });
-      }
-      return vi.fn();
-    });
     mockCheckHoursLogged.mockResolvedValue({
       data: {
         success: true,
@@ -65,8 +35,8 @@ describe('CheckHoursPage', () => {
           fullName: 'Jane Smith',
           schoolName: 'Central High',
           gradeLevel: '10',
-          pdfTemplateId: '',
         },
+        schoolForm: { id: 'central-template', name: 'Central High School Form' },
         totalHours: 5,
         events: [
           {
@@ -128,7 +98,7 @@ describe('CheckHoursPage', () => {
     expect(screen.getByText('Central High School Form')).toBeInTheDocument();
   });
 
-  it('shows the assigned school form when the student has a template override', async () => {
+  it('shows a fallback when no school form is configured', async () => {
     mockCheckHoursLogged.mockResolvedValueOnce({
       data: {
         success: true,
@@ -140,8 +110,8 @@ describe('CheckHoursPage', () => {
           fullName: 'Jane Smith',
           schoolName: 'Central High',
           gradeLevel: '10',
-          pdfTemplateId: 'default-template',
         },
+        schoolForm: null,
         totalHours: 0,
         events: [],
       },
@@ -159,7 +129,7 @@ describe('CheckHoursPage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Default School Form')).toBeInTheDocument();
+      expect(screen.getByText('No form configured')).toBeInTheDocument();
     });
   });
 

--- a/functions/src/checkHoursLogged.js
+++ b/functions/src/checkHoursLogged.js
@@ -69,6 +69,74 @@ function getHours(entry) {
   return typeof entry.hoursWorked === 'number' ? entry.hoursWorked : 0;
 }
 
+function normalizeTemplateText(value = '') {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+const SCHOOL_TEMPLATE_ALIASES = [
+  { school: ['bishopmoore', 'bishopmoorecatholic'], template: ['bishopmoore'] },
+  { school: ['thefirstacademy', 'firstacademy', 'tfa'], template: ['thefirstacademy', 'firstacademy', 'tfa'] },
+];
+
+function findTemplateForSchool(schoolName, templates = []) {
+  const normalizedSchool = normalizeTemplateText(schoolName);
+  if (!normalizedSchool) return null;
+
+  const templateMatches = (template, values) => {
+    const normalizedTemplate = normalizeTemplateText(`${template.name || ''} ${template.fileName || ''}`);
+    return values.some((value) => normalizedTemplate.includes(value));
+  };
+
+  const exactMatch = templates.find((template) => {
+    const normalizedTemplate = normalizeTemplateText(`${template.name || ''} ${template.fileName || ''}`);
+    return normalizedTemplate &&
+      (normalizedTemplate.includes(normalizedSchool) || normalizedSchool.includes(normalizedTemplate));
+  });
+  if (exactMatch) return exactMatch;
+
+  const alias = SCHOOL_TEMPLATE_ALIASES.find((item) =>
+    item.school.some((value) => normalizedSchool.includes(value))
+  );
+  if (alias) {
+    const aliasMatch = templates.find((template) => templateMatches(template, alias.template));
+    if (aliasMatch) return aliasMatch;
+  }
+
+  const ocpsTemplate = templates.find((template) => templateMatches(template, ['ocps']));
+  if (ocpsTemplate) return ocpsTemplate;
+
+  return null;
+}
+
+function getEffectivePdfTemplate(student = {}, templates = [], defaultTemplateId = null) {
+  if (student.pdfTemplateId) {
+    return templates.find((template) => template.id === student.pdfTemplateId) || null;
+  }
+
+  const schoolTemplate = findTemplateForSchool(student.schoolName, templates);
+  if (schoolTemplate) return schoolTemplate;
+
+  return defaultTemplateId ? templates.find((template) => template.id === defaultTemplateId) || null : null;
+}
+
+async function getSchoolFormForStudent(db, student) {
+  const [templatesSnap, defaultsSnap] = await Promise.all([
+    db.collection('pdfTemplates').get(),
+    db.collection('settings').doc('pdfDefaults').get(),
+  ]);
+  const templates = templatesSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+  const defaultTemplateId = defaultsSnap.exists ? defaultsSnap.data().defaultTemplateId : null;
+  const template = getEffectivePdfTemplate(student, templates, defaultTemplateId);
+
+  return template
+    ? {
+        id: template.id,
+        name: template.name || template.fileName || template.id,
+        fileName: template.fileName || '',
+      }
+    : null;
+}
+
 function publicStudentProfile(student, studentId) {
   return {
     id: studentId,
@@ -78,7 +146,6 @@ function publicStudentProfile(student, studentId) {
     schoolName: student.schoolName || '',
     gradeLevel: student.gradeLevel || '',
     gradYear: student.gradYear || '',
-    pdfTemplateId: student.pdfTemplateId || '',
   };
 }
 
@@ -104,6 +171,7 @@ export const checkHoursLogged = onCall({ cors: true }, async (request) => {
     if (!studentDoc.exists) {
       throw new HttpsError('not-found', 'Student not found');
     }
+    const student = studentDoc.data();
 
     const entriesSnap = await db.collection('timeEntries')
       .where('studentId', '==', parsed.studentId)
@@ -153,7 +221,8 @@ export const checkHoursLogged = onCall({ cors: true }, async (request) => {
     return {
       success: true,
       scannedEventId: parsed.eventId,
-      student: publicStudentProfile(studentDoc.data(), studentDoc.id),
+      student: publicStudentProfile(student, studentDoc.id),
+      schoolForm: await getSchoolFormForStudent(db, student),
       events,
       totalHours: events.reduce((sum, event) => sum + event.totalHours, 0),
     };

--- a/functions/test/checkHoursLogged.test.js
+++ b/functions/test/checkHoursLogged.test.js
@@ -21,8 +21,10 @@ const makeTimestamp = (iso) => ({
 const mockCollection = jest.fn();
 const mockStudentDoc = jest.fn();
 const mockEventDoc = jest.fn();
+const mockSettingsDoc = jest.fn();
 const mockWhere = jest.fn();
 const mockGet = jest.fn();
+const mockTemplatesGet = jest.fn();
 
 jest.unstable_mockModule('firebase-admin/firestore', () => ({
   getFirestore: () => ({
@@ -58,6 +60,12 @@ describe('checkHoursLogged Cloud Function', () => {
       if (name === 'events') {
         return { doc: mockEventDoc };
       }
+      if (name === 'pdfTemplates') {
+        return { get: mockTemplatesGet };
+      }
+      if (name === 'settings') {
+        return { doc: mockSettingsDoc };
+      }
       return { where: mockWhere };
     });
 
@@ -88,6 +96,24 @@ describe('checkHoursLogged Cloud Function', () => {
     }));
 
     mockWhere.mockReturnValue({ get: mockGet });
+    mockTemplatesGet.mockResolvedValue({
+      docs: [
+        {
+          id: 'central-template',
+          data: () => ({ name: 'Central High School Form', fileName: 'central.pdf' }),
+        },
+        {
+          id: 'default-template',
+          data: () => ({ name: 'Default School Form', fileName: 'default.pdf' }),
+        },
+      ],
+    });
+    mockSettingsDoc.mockReturnValue({
+      get: jest.fn().mockResolvedValue({
+        exists: true,
+        data: () => ({ defaultTemplateId: 'default-template' }),
+      }),
+    });
     mockGet.mockResolvedValue({
       docs: [
         {
@@ -145,7 +171,11 @@ describe('checkHoursLogged Cloud Function', () => {
       schoolName: 'Central High',
       gradeLevel: '10',
       gradYear: '',
-      pdfTemplateId: 'central-template',
+    });
+    expect(result.schoolForm).toEqual({
+      id: 'central-template',
+      name: 'Central High School Form',
+      fileName: 'central.pdf',
     });
     expect(result.student.email).toBeUndefined();
     expect(result.totalHours).toBe(5);
@@ -162,6 +192,31 @@ describe('checkHoursLogged Cloud Function', () => {
     expect(result.scannedEventId).toBeNull();
     expect(result.student.fullName).toBe('Jane Smith');
     expect(result.totalHours).toBe(5);
+  });
+
+  it('falls back to the default school form when no student or school template matches', async () => {
+    mockStudentDoc.mockReturnValueOnce({
+      get: jest.fn().mockResolvedValue({
+        id: 'student123',
+        exists: true,
+        data: () => ({
+          firstName: 'Jane',
+          lastName: 'Smith',
+          schoolName: 'Unknown Academy',
+          gradeLevel: '10',
+        }),
+      }),
+    });
+
+    const result = await checkHoursLogged({
+      data: { qrData: 'student123' },
+    });
+
+    expect(result.schoolForm).toEqual({
+      id: 'default-template',
+      name: 'Default School Form',
+      fileName: 'default.pdf',
+    });
   });
 
   it('calculates credited hours from timestamps before falling back to stored hoursWorked', async () => {


### PR DESCRIPTION
## Summary
- resolve the effective School Form inside checkHoursLogged using Admin SDK access
- remove direct public /hours reads from pdfTemplates and settings
- display the schoolForm returned by the callable response

## Why
The /hours route is public, but pdfTemplates and settings are admin-only in Firestore rules. Resolving the form server-side matches production permissions and avoids client-side listener failures.

## Tests
- npm test -- CheckHoursPage.test.jsx
- npm test -- checkHoursLogged.test.js
- npm test