### PR TITLE
Add College grade option

### DIFF
--- a/frontend/src/pages/EventStudentsPage.test.jsx
+++ b/frontend/src/pages/EventStudentsPage.test.jsx
@@ -317,7 +317,7 @@ describe('EventStudentsPage', () => {
         expect(screen.getByText('Add New Student')).toBeInTheDocument();
     });
 
-    it('allows selecting grades from Kindergarten through 12th in Add Student modal', async () => {
+    it('allows selecting grades from Kindergarten through College in Add Student modal', async () => {
         renderPage();
         await waitFor(() => screen.getByRole('button', { name: /\+ Add Student/i }));
         fireEvent.click(screen.getByRole('button', { name: /\+ Add Student/i }));
@@ -325,6 +325,7 @@ describe('EventStudentsPage', () => {
         const gradeSelect = screen.getAllByRole('combobox')[0];
         expect(within(gradeSelect).getByRole('option', { name: 'Kindergarten' })).toHaveValue('K');
         expect(within(gradeSelect).getByRole('option', { name: '12th Grade' })).toHaveValue('12');
+        expect(within(gradeSelect).getByRole('option', { name: 'College' })).toHaveValue('College');
     });
 
     it('opens Import modal on button click', async () => {

--- a/frontend/src/pages/StudentDetailPage.test.jsx
+++ b/frontend/src/pages/StudentDetailPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import StudentDetailPage from './StudentDetailPage';
@@ -209,6 +209,20 @@ describe('StudentDetailPage', () => {
         expect(screen.getByRole('button', { name: /Print Service Log/i })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /Print Badge/i })).toBeInTheDocument();
       });
+    });
+
+    it('should include College in the edit student grade options', async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Edit Student/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /Edit Student/i }));
+
+      const gradeSelect = screen.getByRole('combobox');
+      expect(within(gradeSelect).getByRole('option', { name: 'College' })).toHaveValue('College');
     });
 
     it('should render time entries table or service log', async () => {

--- a/frontend/src/utils/grades.js
+++ b/frontend/src/utils/grades.js
@@ -4,6 +4,7 @@ export const GRADE_LEVEL_OPTIONS = [
     const grade = String(index + 1);
     return { value: grade, label: `${grade}${getOrdinalSuffix(index + 1)} Grade` };
   }),
+  { value: 'College', label: 'College' },
 ];
 
 function getOrdinalSuffix(grade) {

--- a/frontend/src/utils/grades.test.js
+++ b/frontend/src/utils/grades.test.js
@@ -2,9 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { GRADE_LEVEL_OPTIONS } from './grades';
 
 describe('GRADE_LEVEL_OPTIONS', () => {
-  it('includes grades from Kindergarten through 12th grade', () => {
-    expect(GRADE_LEVEL_OPTIONS).toHaveLength(13);
+  it('includes grades from Kindergarten through 12th grade and College', () => {
+    expect(GRADE_LEVEL_OPTIONS).toHaveLength(14);
     expect(GRADE_LEVEL_OPTIONS[0]).toEqual({ value: 'K', label: 'Kindergarten' });
-    expect(GRADE_LEVEL_OPTIONS.at(-1)).toEqual({ value: '12', label: '12th Grade' });
+    expect(GRADE_LEVEL_OPTIONS.at(-2)).toEqual({ value: '12', label: '12th Grade' });
+    expect(GRADE_LEVEL_OPTIONS.at(-1)).toEqual({ value: 'College', label: 'College' });
   });
 });


### PR DESCRIPTION
## Summary
- add College to the shared grade-level options
- cover the option in the Student Details edit modal and event add-student modal tests
- update shared grade option expectations

## Tests
- npm test -- --run src/utils/grades.test.js src/pages/EventStudentsPage.test.jsx src/pages/StudentDetailPage.test.jsx

Resolves #70