### PR TITLE
Improve PDF activity date formatting

### DIFF
--- a/frontend/src/pages/EventStudentsPage.jsx
+++ b/frontend/src/pages/EventStudentsPage.jsx
@@ -16,7 +16,7 @@ import {
     writeBatch,
 } from 'firebase/firestore';
 import { ref, getDownloadURL } from 'firebase/storage';
-import { generateFilledPdf, getEffectivePdfTemplate, mergePdfs, openPdfForPrinting } from '../utils/pdfTemplateUtils';
+import { formatActivityDateRanges, generateFilledPdf, getEffectivePdfTemplate, mergePdfs, openPdfForPrinting } from '../utils/pdfTemplateUtils';
 import { useAuth } from '../contexts/AuthContext';
 import { useEvent } from '../contexts/EventContext';
 import Button from '../components/common/Button';
@@ -338,10 +338,7 @@ export default function EventStudentsPage() {
 
             return {
                 name: activity.name,
-                dateDisplay: uniqueDates.map(date => {
-                    const parsed = new Date(date);
-                    return `${parsed.getUTCMonth() + 1}/${parsed.getUTCDate()}/${parsed.getUTCFullYear().toString().slice(-2)}`;
-                }).join(', '),
+                dateDisplay: formatActivityDateRanges(uniqueDates),
                 sortDate: uniqueDates[0],
                 totalHours: totalHours.toFixed(2)
             };

--- a/frontend/src/pages/EventStudentsPage.test.jsx
+++ b/frontend/src/pages/EventStudentsPage.test.jsx
@@ -12,6 +12,7 @@ vi.mock('firebase/storage', () => ({
 }));
 
 vi.mock('../utils/pdfTemplateUtils', () => ({
+    formatActivityDateRanges: vi.fn((dates = []) => dates.join(', ')),
     generateFilledPdf: vi.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
     getEffectivePdfTemplate: vi.fn((student = {}, templates = [], defaultTemplateId = null) => {
         if (student.pdfTemplateId) {

--- a/frontend/src/pages/StudentDetailPage.jsx
+++ b/frontend/src/pages/StudentDetailPage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { printInNewWindow, createPrintDocument } from '../utils/printUtils';
 import { formatTime, formatHours } from '../utils/hourCalculations';
-import { generateFilledPdf, openPdfForPrinting } from '../utils/pdfTemplateUtils';
+import { formatActivityDateRanges, generateFilledPdf, openPdfForPrinting } from '../utils/pdfTemplateUtils';
 
 import { db, functions, storage } from '../utils/firebase';
 import { doc, getDoc, collection, query, where, onSnapshot, orderBy, Timestamp, updateDoc, getDocs } from 'firebase/firestore';
@@ -204,26 +204,7 @@ export default function StudentDetailPage() {
                 new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(e.checkInTime.toDate())
             ))].sort();
 
-            // 2. Identify consecutive groups
-            const groups = [];
-            if (uniqueDates.length > 0) {
-                let currentGroup = [uniqueDates[0]];
-                for (let i = 1; i < uniqueDates.length; i++) {
-                    const prev = new Date(uniqueDates[i - 1]);
-                    const curr = new Date(uniqueDates[i]);
-                    const diffDays = (curr - prev) / (1000 * 60 * 60 * 24);
-
-                    if (diffDays === 1) {
-                        currentGroup.push(uniqueDates[i]);
-                    } else {
-                        groups.push(currentGroup);
-                        currentGroup = [uniqueDates[i]];
-                    }
-                }
-                groups.push(currentGroup);
-            }
-
-            // 3. Default Checkout Times to end of Activity if one is missing
+            // 2. Default Checkout Times to end of Activity if one is missing
             const updatedActivityEntries = activityEntries.map(entry => {
                 // Check if checkoutTime is missing, null, or undefined
                 if (!entry.checkOutTime) {
@@ -242,17 +223,6 @@ export default function StudentDetailPage() {
                 return entry;
             });
 
-            // 4. Format strings like "1/1/26 - 1/3/26, 1/5/26"
-            // Use UTC methods since uniqueDates are YYYY-MM-DD strings parsed as midnight UTC
-            const dateStrings = groups.map(group => {
-                const start = new Date(group[0]);
-                const end = new Date(group[group.length - 1]);
-                const startStr = `${start.getUTCMonth() + 1}/${start.getUTCDate()}/${start.getUTCFullYear().toString().slice(-2)}`;
-                const endStr = `${end.getUTCMonth() + 1}/${end.getUTCDate()}/${end.getUTCFullYear().toString().slice(-2)}`;
-
-                return group.length > 1 ? `${startStr} - ${endStr}` : startStr;
-            });
-
             const totalHours = updatedActivityEntries.reduce((acc, entry) => {
                 // Only Count the Hours if not defaulted                 
                 if (entry.isDefaulted) return acc;
@@ -263,7 +233,7 @@ export default function StudentDetailPage() {
 
             return {
                 name: activity.name,
-                dateDisplay: dateStrings.join(', '),
+                dateDisplay: formatActivityDateRanges(uniqueDates),
                 sortDate: uniqueDates[0],
                 totalHours: totalHours.toFixed(2)
             };

--- a/frontend/src/pages/StudentDetailPage.manualEntry.test.jsx
+++ b/frontend/src/pages/StudentDetailPage.manualEntry.test.jsx
@@ -53,6 +53,7 @@ vi.mock('firebase/storage', () => ({
 
 // Mock pdfTemplateUtils
 vi.mock('../utils/pdfTemplateUtils', () => ({
+    formatActivityDateRanges: vi.fn((dates = []) => dates.join(', ')),
     generateFilledPdf: vi.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
     openPdfForPrinting: vi.fn(),
     downloadPdf: vi.fn(),

--- a/frontend/src/pages/StudentDetailPage.test.jsx
+++ b/frontend/src/pages/StudentDetailPage.test.jsx
@@ -82,6 +82,7 @@ vi.mock('firebase/storage', () => ({
 
 // Mock pdfTemplateUtils
 vi.mock('../utils/pdfTemplateUtils', () => ({
+  formatActivityDateRanges: vi.fn((dates = []) => dates.join(', ')),
   generateFilledPdf: vi.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
   openPdfForPrinting: vi.fn(),
   downloadPdf: vi.fn(),

--- a/frontend/src/pages/StudentsPage.jsx
+++ b/frontend/src/pages/StudentsPage.jsx
@@ -4,7 +4,7 @@ import { printInNewWindow, createPrintDocument } from '../utils/printUtils';
 import { db, storage } from '../utils/firebase';
 import { collection, onSnapshot, addDoc, serverTimestamp, query, where, doc, updateDoc } from 'firebase/firestore';
 import { ref, getDownloadURL } from 'firebase/storage';
-import { generateFilledPdf, mergePdfs, openPdfForPrinting } from '../utils/pdfTemplateUtils';
+import { formatActivityDateRanges, generateFilledPdf, mergePdfs, openPdfForPrinting } from '../utils/pdfTemplateUtils';
 import { useEvent } from '../contexts/EventContext';
 import Button from '../components/common/Button';
 import Spinner from '../components/common/Spinner';
@@ -199,35 +199,6 @@ export default function StudentsPage() {
         new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(e.checkInTime.toDate())
       ))].sort();
 
-      // Identify consecutive groups
-      const groups = [];
-      if (uniqueDates.length > 0) {
-        let currentGroup = [uniqueDates[0]];
-        for (let i = 1; i < uniqueDates.length; i++) {
-          const prev = new Date(uniqueDates[i - 1]);
-          const curr = new Date(uniqueDates[i]);
-          const diffDays = (curr - prev) / (1000 * 60 * 60 * 24);
-
-          if (diffDays === 1) {
-            currentGroup.push(uniqueDates[i]);
-          } else {
-            groups.push(currentGroup);
-            currentGroup = [uniqueDates[i]];
-          }
-        }
-        groups.push(currentGroup);
-      }
-
-      // Format strings like "1/1/26 - 1/3/26, 1/5/26"
-      const dateStrings = groups.map(group => {
-        const start = new Date(group[0]);
-        const end = new Date(group[group.length - 1]);
-        const startStr = `${start.getUTCMonth() + 1}/${start.getUTCDate()}/${start.getUTCFullYear().toString().slice(-2)}`;
-        const endStr = `${end.getUTCMonth() + 1}/${end.getUTCDate()}/${end.getUTCFullYear().toString().slice(-2)}`;
-
-        return group.length > 1 ? `${startStr} - ${endStr}` : startStr;
-      });
-
       const totalHours = activityEntries.reduce((acc, entry) => {
         const diff = (entry.checkOutTime.seconds - entry.checkInTime.seconds) / 3600;
         return acc + roundTime(diff);
@@ -235,7 +206,7 @@ export default function StudentsPage() {
 
       return {
         name: activity.name,
-        dateDisplay: dateStrings.join(', '),
+        dateDisplay: formatActivityDateRanges(uniqueDates),
         sortDate: uniqueDates[0],
         totalHours: totalHours.toFixed(2)
       };

--- a/frontend/src/pages/StudentsPage.test.jsx
+++ b/frontend/src/pages/StudentsPage.test.jsx
@@ -19,6 +19,7 @@ vi.mock('firebase/storage', () => ({
 
 // Mock pdfTemplateUtils
 vi.mock('../utils/pdfTemplateUtils', () => ({
+  formatActivityDateRanges: vi.fn((dates = []) => dates.join(', ')),
   generateFilledPdf: vi.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
   mergePdfs: vi.fn((arr) => Promise.resolve(arr[0] || new Uint8Array([1, 2, 3]))),
   openPdfForPrinting: vi.fn(),

--- a/frontend/src/utils/pdfTemplateUtils.js
+++ b/frontend/src/utils/pdfTemplateUtils.js
@@ -93,6 +93,70 @@ function formatDateForReport(date) {
   }).format(date);
 }
 
+function parseDateOnlyParts(dateString) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString || '');
+  if (!match) return null;
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+  };
+}
+
+function dateOnlyUtcMs(dateString) {
+  const parts = parseDateOnlyParts(dateString);
+  return parts ? Date.UTC(parts.year, parts.month - 1, parts.day) : Number.NaN;
+}
+
+function formatDateOnlyForActivity(dateString, includeYear = false) {
+  const parts = parseDateOnlyParts(dateString);
+  if (!parts) return '';
+  const monthDay = `${parts.month}/${parts.day}`;
+  return includeYear ? `${monthDay}/${String(parts.year).slice(-2)}` : monthDay;
+}
+
+export function formatActivityDateRanges(dateStrings = [], { includeYear = false } = {}) {
+  const uniqueDates = [...new Set(dateStrings)]
+    .filter(dateString => Number.isFinite(dateOnlyUtcMs(dateString)))
+    .sort();
+
+  if (uniqueDates.length === 0) return '';
+
+  const groups = [];
+  let currentGroup = [uniqueDates[0]];
+
+  for (let i = 1; i < uniqueDates.length; i += 1) {
+    const prevMs = dateOnlyUtcMs(uniqueDates[i - 1]);
+    const currMs = dateOnlyUtcMs(uniqueDates[i]);
+    const diffDays = (currMs - prevMs) / (1000 * 60 * 60 * 24);
+
+    if (diffDays === 1) {
+      currentGroup.push(uniqueDates[i]);
+    } else {
+      groups.push(currentGroup);
+      currentGroup = [uniqueDates[i]];
+    }
+  }
+  groups.push(currentGroup);
+
+  return groups.map(group => {
+    const start = formatDateOnlyForActivity(group[0], includeYear);
+    const end = formatDateOnlyForActivity(group[group.length - 1], includeYear);
+    return group.length > 1 ? `${start}-${end}` : start;
+  }).join(', ');
+}
+
+export function getFittingFontSize({ text, font, fontSize, maxWidth, minFontSize = 6 }) {
+  if (!text || !font || !maxWidth || maxWidth <= 0) return fontSize;
+  if (font.widthOfTextAtSize(text, fontSize) <= maxWidth) return fontSize;
+
+  const widthAtOnePoint = font.widthOfTextAtSize(text, 1);
+  if (!widthAtOnePoint) return fontSize;
+
+  const fitted = maxWidth / widthAtOnePoint;
+  return Math.max(minFontSize, Math.min(fontSize, fitted));
+}
+
 function formatTimeForReport(date) {
   return new Intl.DateTimeFormat('en-US', {
     timeZone: REPORT_TIME_ZONE,
@@ -147,7 +211,7 @@ export const FIELD_KEY_OPTIONS = [
  */
 export const ACTIVITY_COLUMN_OPTIONS = [
   { key: 'activityOrg', label: 'Organization + Activity', preview: 'First Baptist VBS AM' },
-  { key: 'activityDates', label: 'Date(s) of Service', preview: '6/9/26 - 6/13/26' },
+  { key: 'activityDates', label: 'Date(s) of Service', preview: '6/9-6/13' },
   { key: 'activityContact', label: 'Contact Name', preview: 'Jane Smith' },
   { key: 'activityHours', label: 'Hours Completed', preview: '12.50' },
 ];
@@ -317,17 +381,21 @@ export async function generateFilledPdf(templatePdfBytes, fields, data) {
         (field.columns || []).forEach((col) => {
           const x = (col.xPercent / 100) * width;
           const colFontSize = col.fontSize || 10;
-          // Shift baseline down by ascent so top of text aligns with yPercent
-          const y = height - (rowYPct / 100) * height - (colFontSize * ASCENT_RATIO);
+          const maxWidth = col.maxWidth ? (col.maxWidth / 100) * width : undefined;
           const value = String(resolveActivityColumnValue(col.type === 'customText' ? col : col.key, activity, data.event));
+          const drawFontSize = col.key === 'activityDates'
+            ? getFittingFontSize({ text: value, font, fontSize: colFontSize, maxWidth })
+            : colFontSize;
+          // Shift baseline down by ascent so top of text aligns with yPercent
+          const y = height - (rowYPct / 100) * height - (drawFontSize * ASCENT_RATIO);
 
           page.drawText(value, {
             x,
             y,
-            size: colFontSize,
+            size: drawFontSize,
             font,
             color: rgb(0, 0, 0),
-            maxWidth: col.maxWidth ? (col.maxWidth / 100) * width : undefined,
+            maxWidth,
           });
         });
       });

--- a/frontend/src/utils/pdfTemplateUtils.test.js
+++ b/frontend/src/utils/pdfTemplateUtils.test.js
@@ -13,8 +13,10 @@ import {
   openPdfForPrinting,
   downloadPdf,
   getPdfPageDimensions,
+  formatActivityDateRanges,
+  getFittingFontSize,
 } from './pdfTemplateUtils';
-import { PDFDocument } from 'pdf-lib';
+import { PDFDocument, StandardFonts } from 'pdf-lib';
 
 describe('pdfTemplateUtils', () => {
   describe('FIELD_KEY_OPTIONS', () => {
@@ -257,6 +259,64 @@ describe('pdfTemplateUtils', () => {
     it('should handle missing activity data', () => {
       expect(resolveActivityColumnValue('activityDates', {}, mockEvent)).toBe('');
       expect(resolveActivityColumnValue('activityHours', {}, mockEvent)).toBe('0');
+    });
+  });
+
+  describe('formatActivityDateRanges', () => {
+    it('should format a single date without the year by default', () => {
+      expect(formatActivityDateRanges(['2026-06-09'])).toBe('6/9');
+    });
+
+    it('should compact multiple consecutive dates into a range', () => {
+      expect(formatActivityDateRanges([
+        '2026-06-09',
+        '2026-06-10',
+        '2026-06-11',
+        '2026-06-12',
+      ])).toBe('6/9-6/12');
+    });
+
+    it('should compact mixed consecutive and non-consecutive dates', () => {
+      expect(formatActivityDateRanges([
+        '2026-06-13',
+        '2026-06-10',
+        '2026-06-09',
+        '2026-06-11',
+        '2026-06-13',
+      ])).toBe('6/9-6/11, 6/13');
+    });
+
+    it('should include years when requested', () => {
+      expect(formatActivityDateRanges(['2026-06-09', '2026-06-10'], { includeYear: true })).toBe('6/9/26-6/10/26');
+    });
+  });
+
+  describe('getFittingFontSize', () => {
+    it('should preserve the configured font size when text fits', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+      expect(getFittingFontSize({
+        text: '6/9',
+        font,
+        fontSize: 10,
+        maxWidth: 80,
+      })).toBe(10);
+    });
+
+    it('should shrink long date text that exceeds the available column width', async () => {
+      const pdfDoc = await PDFDocument.create();
+      const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+      const fitted = getFittingFontSize({
+        text: '6/9-6/11, 6/13, 6/15-6/19',
+        font,
+        fontSize: 10,
+        maxWidth: 100,
+      });
+
+      expect(fitted).toBeLessThan(10);
+      expect(font.widthOfTextAtSize('6/9-6/11, 6/13, 6/15-6/19', fitted)).toBeLessThanOrEqual(100.001);
     });
   });
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "bootstrap:local": "node bootstrap-local.js",
     "seed:local": "node generate-test-users.js && node generate-time-entries.js",
+    "seed:activity-dates": "node seed-activity-date-permutations.js",
     "seed:prod": "NODE_ENV=production node generate-test-users.js && NODE_ENV=production node generate-time-entries.js",
     "setup-admin": "node setup-admin.js",
     "import:vbs": "node import-vbs-registrations.js",

--- a/scripts/seed-activity-date-permutations.js
+++ b/scripts/seed-activity-date-permutations.js
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+
+import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { initializeApp } from 'firebase-admin/app';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { getStorage } from 'firebase-admin/storage';
+
+process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || 'localhost:8080';
+process.env.FIREBASE_STORAGE_EMULATOR_HOST = process.env.FIREBASE_STORAGE_EMULATOR_HOST || 'localhost:9199';
+
+const PROJECT_ID = 'vbs-volunteer-tracker';
+const BUCKET_NAME = 'vbs-volunteer-tracker.firebasestorage.app';
+const SEED_SOURCE = 'issue-115-activity-date-permutations';
+const EVENT_ID = 'issue115-date-permutations';
+const TEMPLATE_ID = 'issue115-compact-date-template';
+const TEMPLATE_STORAGE_PATH = 'pdfTemplates/issue115-compact-date-template.pdf';
+const TEMPLATE_DIR_URL = existsSync(fileURLToPath(new URL('./data/templates/', import.meta.url)))
+  ? new URL('./data/templates/', import.meta.url)
+  : new URL('./templates/', import.meta.url);
+
+const app = initializeApp({
+  projectId: PROJECT_ID,
+  storageBucket: BUCKET_NAME,
+});
+const db = getFirestore(app);
+const bucket = getStorage(app).bucket(BUCKET_NAME);
+
+const students = [
+  {
+    id: 'issue115-single-date',
+    firstName: 'Ivy',
+    lastName: 'SingleDate',
+    schoolName: 'West Orange High',
+    gradeLevel: 10,
+    gradYear: 2028,
+    notes: 'One service date. Activity Table should show 6/9.',
+  },
+  {
+    id: 'issue115-consecutive-range',
+    firstName: 'Caleb',
+    lastName: 'ConsecutiveRange',
+    schoolName: 'West Orange High',
+    gradeLevel: 11,
+    gradYear: 2027,
+    notes: 'Four consecutive dates. Activity Table should show 6/9-6/12.',
+  },
+  {
+    id: 'issue115-mixed-dates',
+    firstName: 'Mia',
+    lastName: 'MixedDates',
+    schoolName: 'West Orange High',
+    gradeLevel: 9,
+    gradYear: 2029,
+    notes: 'Consecutive dates plus a gap. Activity Table should show 6/9-6/11, 6/13.',
+  },
+  {
+    id: 'issue115-duplicate-dates',
+    firstName: 'Leo',
+    lastName: 'DuplicateDates',
+    schoolName: 'West Orange High',
+    gradeLevel: 12,
+    gradYear: 2026,
+    notes: 'Multiple entries on one date plus another date. Activity Table should dedupe to 6/9-6/10.',
+  },
+  {
+    id: 'issue115-long-date-list',
+    firstName: 'Nina',
+    lastName: 'LongDateList',
+    schoolName: 'West Orange High',
+    gradeLevel: 10,
+    gradYear: 2028,
+    notes: 'Many non-consecutive dates. Activity Table should stay compact and shrink if needed.',
+  },
+  {
+    id: 'issue115-multiple-activities',
+    firstName: 'Taylor',
+    lastName: 'MultipleActivities',
+    schoolName: 'West Orange High',
+    gradeLevel: 8,
+    gradYear: 2030,
+    notes: 'Two activity rows: one single date and one date range.',
+  },
+];
+
+const activities = [
+  {
+    id: 'morning-service',
+    name: 'Morning Service',
+    startDate: '2026-06-09',
+    endDate: '2026-06-13',
+    startTime: '09:00',
+    endTime: '12:00',
+  },
+  {
+    id: 'afternoon-service',
+    name: 'Afternoon Service',
+    startDate: '2026-06-09',
+    endDate: '2026-06-13',
+    startTime: '13:00',
+    endTime: '15:00',
+  },
+  {
+    id: 'extended-service',
+    name: 'Extended Service',
+    startDate: '2026-06-01',
+    endDate: '2026-06-19',
+    startTime: '09:00',
+    endTime: '12:00',
+  },
+];
+
+const scenarios = {
+  'issue115-single-date': [
+    { activityId: 'morning-service', date: '2026-06-09', start: '09:00', end: '12:00' },
+  ],
+  'issue115-consecutive-range': [
+    { activityId: 'morning-service', date: '2026-06-09', start: '09:00', end: '12:00' },
+    { activityId: 'morning-service', date: '2026-06-10', start: '09:00', end: '12:00' },
+    { activityId: 'morning-service', date: '2026-06-11', start: '09:00', end: '12:00' },
+    { activityId: 'morning-service', date: '2026-06-12', start: '09:00', end: '12:00' },
+  ],
+  'issue115-mixed-dates': [
+    { activityId: 'morning-service', date: '2026-06-09', start: '09:00', end: '12:00' },
+    { activityId: 'morning-service', date: '2026-06-10', start: '09:00', end: '12:00' },
+    { activityId: 'morning-service', date: '2026-06-11', start: '09:00', end: '12:00' },
+    { activityId: 'morning-service', date: '2026-06-13', start: '09:00', end: '12:00' },
+  ],
+  'issue115-duplicate-dates': [
+    { activityId: 'morning-service', date: '2026-06-09', start: '09:00', end: '10:30' },
+    { activityId: 'morning-service', date: '2026-06-09', start: '10:30', end: '12:00' },
+    { activityId: 'morning-service', date: '2026-06-10', start: '09:00', end: '12:00' },
+  ],
+  'issue115-long-date-list': [
+    { activityId: 'extended-service', date: '2026-06-01', start: '09:00', end: '12:00' },
+    { activityId: 'extended-service', date: '2026-06-03', start: '09:00', end: '12:00' },
+    { activityId: 'extended-service', date: '2026-06-05', start: '09:00', end: '12:00' },
+    { activityId: 'extended-service', date: '2026-06-07', start: '09:00', end: '12:00' },
+    { activityId: 'extended-service', date: '2026-06-09', start: '09:00', end: '12:00' },
+    { activityId: 'extended-service', date: '2026-06-11', start: '09:00', end: '12:00' },
+    { activityId: 'extended-service', date: '2026-06-13', start: '09:00', end: '12:00' },
+  ],
+  'issue115-multiple-activities': [
+    { activityId: 'morning-service', date: '2026-06-09', start: '09:00', end: '12:00' },
+    { activityId: 'afternoon-service', date: '2026-06-10', start: '13:00', end: '15:00' },
+    { activityId: 'afternoon-service', date: '2026-06-11', start: '13:00', end: '15:00' },
+    { activityId: 'afternoon-service', date: '2026-06-12', start: '13:00', end: '15:00' },
+  ],
+};
+
+function asDate(date, time) {
+  return new Date(`${date}T${time}:00-04:00`);
+}
+
+function hoursBetween(start, end) {
+  return Math.round(((end.getTime() - start.getTime()) / 3600000) * 4) / 4;
+}
+
+function buildEntry(studentId, row, index) {
+  const checkIn = asDate(row.date, row.start);
+  const checkOut = asDate(row.date, row.end);
+  const hoursWorked = hoursBetween(checkIn, checkOut);
+
+  return {
+    id: `${studentId}-${index + 1}`,
+    data: {
+      studentId,
+      eventId: EVENT_ID,
+      activityId: row.activityId,
+      date: row.date,
+      checkInTime: Timestamp.fromDate(checkIn),
+      checkOutTime: Timestamp.fromDate(checkOut),
+      checkInBy: 'issue115_seed',
+      checkInMethod: 'script',
+      checkOutBy: 'issue115_seed',
+      checkOutMethod: 'script',
+      entry_source: SEED_SOURCE,
+      seedSource: SEED_SOURCE,
+      hoursWorked,
+      rawMinutes: Math.round(hoursWorked * 60),
+      reviewStatus: 'approved',
+      flags: [],
+      isVoided: false,
+      createdAt: Timestamp.now(),
+    },
+  };
+}
+
+async function deleteSeedTimeEntries() {
+  const snapshot = await db.collection('timeEntries').where('seedSource', '==', SEED_SOURCE).get();
+  if (snapshot.empty) return 0;
+
+  const batch = db.batch();
+  snapshot.docs.forEach(doc => batch.delete(doc.ref));
+  await batch.commit();
+  return snapshot.size;
+}
+
+function loadTemplateFields() {
+  const mapping = JSON.parse(readFileSync(new URL('ocps_mapping.json', TEMPLATE_DIR_URL), 'utf8'));
+  const fields = mapping.templates[0].fields;
+  return fields.map(field => {
+    if (field.type !== 'activityTable') return field;
+
+    return {
+      ...field,
+      label: 'Activity Table Date Permutations',
+      maxRows: 7,
+      columns: field.columns.map(column => {
+        if (column.key === 'activityDates') {
+          return { ...column, maxWidth: 14, fontSize: 10 };
+        }
+        return column;
+      }),
+    };
+  });
+}
+
+async function uploadTemplatePdf() {
+  const token = randomUUID();
+  await bucket.upload(fileURLToPath(new URL('ocps-2024-2025_community_service_form_2 (1).pdf', TEMPLATE_DIR_URL)), {
+    destination: TEMPLATE_STORAGE_PATH,
+    contentType: 'application/pdf',
+    metadata: {
+      metadata: {
+        firebaseStorageDownloadTokens: token,
+      },
+    },
+  });
+}
+
+async function seed() {
+  console.log('🔌 Using local Firebase emulators');
+  console.log(`Firestore: ${process.env.FIRESTORE_EMULATOR_HOST}`);
+  console.log(`Storage:   ${process.env.FIREBASE_STORAGE_EMULATOR_HOST}`);
+
+  await uploadTemplatePdf();
+
+  const deletedEntries = await deleteSeedTimeEntries();
+  const batch = db.batch();
+
+  batch.set(db.collection('pdfTemplates').doc(TEMPLATE_ID), {
+    name: 'Issue 115 Compact Date Test Template',
+    fileName: 'ocps-issue115-date-test.pdf',
+    storagePath: TEMPLATE_STORAGE_PATH,
+    pageWidth: 612,
+    pageHeight: 792,
+    pageCount: 1,
+    fields: loadTemplateFields(),
+    seedSource: SEED_SOURCE,
+    updatedAt: Timestamp.now(),
+  }, { merge: true });
+
+  batch.set(db.collection('settings').doc('pdfDefaults'), {
+    defaultTemplateId: TEMPLATE_ID,
+    seedSource: SEED_SOURCE,
+    updatedAt: Timestamp.now(),
+  }, { merge: true });
+
+  batch.set(db.collection('events').doc(EVENT_ID), {
+    name: 'Issue 115 Date Formatting Test Event',
+    organizationName: 'Community Church Date Lab',
+    contactName: 'Heidi Estep',
+    supervisorName: 'Heidi Estep',
+    contactPhone: '(555) 115-0617',
+    description: 'Deterministic local data for testing compact Activity Table date formatting.',
+    startDate: '2026-06-01',
+    endDate: '2026-06-19',
+    typicalStartTime: '09:00',
+    typicalEndTime: '12:00',
+    activities,
+    seedSource: SEED_SOURCE,
+    createdAt: Timestamp.now(),
+    updatedAt: Timestamp.now(),
+  }, { merge: true });
+
+  students.forEach(student => {
+    batch.set(db.collection('students').doc(student.id), {
+      ...student,
+      overrideHours: 0,
+      pdfTemplateId: TEMPLATE_ID,
+      seedSource: SEED_SOURCE,
+      createdAt: Timestamp.now(),
+      updatedAt: Timestamp.now(),
+    }, { merge: true });
+
+    batch.set(db.collection('eventStudents').doc(`${EVENT_ID}_${student.id}`), {
+      eventId: EVENT_ID,
+      studentId: student.id,
+      addedAt: Timestamp.now(),
+      addedBy: 'issue115_seed',
+      seedSource: SEED_SOURCE,
+    }, { merge: true });
+
+    scenarios[student.id].forEach((row, index) => {
+      const entry = buildEntry(student.id, row, index);
+      batch.set(db.collection('timeEntries').doc(entry.id), entry.data);
+    });
+  });
+
+  await batch.commit();
+
+  console.log('\n✅ Issue #115 sample data ready');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log(`Event:       Issue 115 Date Formatting Test Event`);
+  console.log(`Event ID:    ${EVENT_ID}`);
+  console.log(`Template:    Issue 115 Compact Date Test Template`);
+  console.log(`Old entries removed before reseed: ${deletedEntries}`);
+  console.log('\nStudents to inspect:');
+  console.log('  Ivy SingleDate          → single date: 6/9');
+  console.log('  Caleb ConsecutiveRange  → consecutive range: 6/9-6/12');
+  console.log('  Mia MixedDates          → mixed range/list: 6/9-6/11, 6/13');
+  console.log('  Leo DuplicateDates      → duplicate check-ins deduped: 6/9-6/10');
+  console.log('  Nina LongDateList       → long date text/font-fit case');
+  console.log('  Taylor MultipleActivities → multiple Activity Table rows');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+}
+
+seed().catch(error => {
+  console.error('\n❌ Failed to seed issue #115 data:', error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- compact Activity Table service dates into month/day ranges by default
- shrink Activity Table date text based on mapped column width before drawing PDFs
- share date formatting across event, student detail, and all-students print paths
- add deterministic local seed data for testing date formatting permutations

## Tests
- npm test -- src/utils/pdfTemplateUtils.test.js
- npm test -- src/pages/EventStudentsPage.test.jsx src/pages/StudentsPage.test.jsx src/pages/StudentDetailPage.test.jsx src/pages/StudentDetailPage.manualEntry.test.jsx
- npm test
- npm run build
- git diff --check

Note: npm run lint is currently blocked because ESLint cannot find a config file in this checkout.

Resolves #115 